### PR TITLE
Updated to default to the latest release on the 0.18 branch (0.18.7; was 0.18.5)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 # === VERSION ===
 #
-default.elasticsearch[:version]   = "0.18.5"
+default.elasticsearch[:version]   = "0.18.7"
 
 # === PATHS ===
 #


### PR DESCRIPTION
The default ElasticSearch attribute was updated to the latest available bugfix release (0.18.7) - also note that there is a 0.19.x branch which is currently in release candidate stage, however a final release has not yet occurred so 0.18.7 still appears to be the best choice right now.
