### PR TITLE
Update to remove 'which curl' check and just use Chef package management instead

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,6 @@
-elasticsearch = "elasticsearch-#{node.elasticsearch[:version]}"
+include_recipe "elasticsearch::curl"
 
-include_recipe 'elasticsearch::curl' do
-  not_if "which curl"
-end
+elasticsearch = "elasticsearch-#{node.elasticsearch[:version]}"
 
 # Create user and group
 #


### PR DESCRIPTION
Based on discussion in the comments of a68822a1c37594b45dbf1d5c8cf7a63b7af7cf53, submitting a pull request which shows the change I'm talking about.
