### PR TITLE
Removed adding of ec2-user to the elasticsearch group

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,17 +6,16 @@ include_recipe "elasticsearch::curl"
 
 # Create user and group
 #
+group node.elasticsearch[:user] do
+  action :create
+end
+
 user node.elasticsearch[:user] do
   comment "ElasticSearch User"
   home    "#{node.elasticsearch[:dir]}/elasticsearch"
   shell   "/bin/bash"
+  gid     node.elasticsearch[:user]
   action  :create
-end
-group node.elasticsearch[:user] do
-  ( m = [] ) << node.elasticsearch[:user]
-  m << 'ec2-user' if node.recipes.include?('elasticsearch::plugin_aws')
-  members m
-  action :create
 end
 
 # Create ES directories


### PR DESCRIPTION
Removed adding of ec2-user to the elasticsearch group - not all EC2 AMIs have that user (I saw this blow up on EC2 AMI ami-c594ca80), and this appears unused (this is the only reference to 'ec2-user' in the entire codebase). The order of group and user creation was also adjusted so that the group is passed into the user rather than vice versa (less code, "feels" a bit cleaner).
