### PR TITLE
makes mlockall an attribute with a default value of false.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default.elasticsearch[:pid_path]  = "/usr/local/var/run/elasticsearch"
 max_mem = "#{(node.memory.total.to_i - (node.memory.total.to_i/3) ) / 1024}m"
 default.elasticsearch[:min_mem] = "128m"
 default.elasticsearch[:max_mem] = max_mem
+default.elasticsearch[:mlockall] = "false"
 
 # === LIMITS ===
 #

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -15,7 +15,7 @@ path.logs: <%= node.elasticsearch[:log_path] %>
 
 ################################### Memory ####################################
 
-bootstrap.mlockall: true
+bootstrap.mlockall: <%= node.elasticsearch[:mlockall] %>
 
 ################################## Discovery ##################################
 <% if node.elasticsearch[:discovery][:type] %>


### PR DESCRIPTION
Makes mlockall an attribute.
Default value is false, inline with https://github.com/elasticsearch/elasticsearch/issues/567
