### PR TITLE
Increasing the thread stack space

### DIFF
--- a/templates/default/elasticsearch-env.sh.erb
+++ b/templates/default/elasticsearch-env.sh.erb
@@ -12,7 +12,7 @@ ES_JAVA_OPTS="
   -Des.config=<%= node.elasticsearch[:conf_path] %>/elasticsearch.yml
   -Xms<%= node.elasticsearch[:min_mem] %>
   -Xmx<%= node.elasticsearch[:max_mem] %>
-  -Xss128k
+  -Xss256k
   -XX:+UseParNewGC
   -XX:+UseConcMarkSweepGC
   -XX:CMSInitiatingOccupancyFraction=75


### PR DESCRIPTION
While working with the Sematext folks to get SPM running on our QA
environment, we noticed that SPM would not start with Java 6. After
some investigation, the Sematext folks discovered that SPM would not
start because of the low -Xss setting. This change is to address this.
(see https://github.com/karmi/cookbook-elasticsearch/issues/25)
