### PR TITLE
Support for forked elastic search distros

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@ settings = Chef::DataBagItem.load('elasticsearch', 'settings') rescue {}
 # === VERSION ===
 #
 default.elasticsearch[:version]  = "0.19.8"
+default.elasticsearch[:distro]  = "elasticsearch"
 default.elasticsearch[:checksum] = "6cc4c3a2439f48864050ba306c0e3569c064ad9097448b5452e11e3fc7c7d9e6"
 
 # === INDEX ===

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
 elasticsearch = "elasticsearch-#{node.elasticsearch[:version]}"
+distro = "#{node.elasticsearch[:distro]}"
 
 include_recipe "elasticsearch::curl"
 include_recipe "ark"
@@ -50,7 +51,7 @@ end
 # Download, extract, symlink the elasticsearch libraries and binaries
 #
 ark "elasticsearch" do
-  url "https://github.com/downloads/elasticsearch/elasticsearch/#{elasticsearch}.tar.gz"
+  url "https://github.com/downloads/#{distro}/elasticsearch/#{elasticsearch}.tar.gz"
   owner node.elasticsearch[:user]
   group node.elasticsearch[:user]
   version node.elasticsearch[:version]


### PR DESCRIPTION
By parametarizing the account portion of the github tar download path, we can allow forked distributions of elastic search to be installed through this recipe (e.g. those that want to run on master).
