### PR TITLE
Check that monitrc resource is available before using it

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -106,7 +106,7 @@ end
 
 # Add Monit configuration file
 #
-if node.recipes.include?('monit')
+if node.recipes.include?('monit') and defined? monitrc
   monitrc("elasticsearch",
           :pidfile => "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node_name].to_s.gsub(/\W/, '_')}.pid")
 else


### PR DESCRIPTION
There are other monit cookbooks out there such as https://github.com/axsuul/cookbook-monit which don't have a `monitrc` resource. So let's check if that resource exists as well :)
