### PR TITLE
[metadata.rb] add name attribute so directory name doesn't break chef run

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,7 @@ license          "MIT License"
 description      "Installs and configures elasticsearch clusters"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.markdown'))
 version          "0.0.4"
+name             "elasticsearch"
 
 depends 'ark'
 


### PR DESCRIPTION
I was having an issue where the chef run would break because my checkout directory was cookbook-elasticsearch.

This seems to fix that issue.
