### PR TITLE
Network/HTTP/Multicast/Persistence/JMX/Logging/Recovery Settings 

### DIFF
--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -17,3 +17,5 @@ default.elasticsearch[:gateway][:s3][:bucket]        = ( aws['gateway']['s3']['b
 default.elasticsearch[:cloud][:ec2][:security_group] = ( aws['cloud']['ec2']['security_group'] rescue nil )
 default.elasticsearch[:cloud][:aws][:access_key]     = ( aws['cloud']['aws']['access_key']     rescue nil )
 default.elasticsearch[:cloud][:aws][:secret_key]     = ( aws['cloud']['aws']['secret_key']     rescue nil )
+default.elasticsearch[:cloud][:aws][:region]         = ( aws['cloud']['aws']['region']         rescue nil )
+default.elasticsearch[:cloud][:ec2][:endpoint]       = ( aws['cloud']['ec2']['endpoint']       rescue nil )

--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -1,8 +1,8 @@
-Chef::Log.debug "Attempting to loading plugin list from the databag..."
+Chef::Log.debug "Attempting to load plugin list from the databag..."
 
 plugins = Chef::DataBagItem.load('elasticsearch', 'plugins').to_hash['plugins'] rescue {}
 
-Chef::Log.debug "Loaded these plugins: #{plugins.keys}"
+Chef::Log.debug "Plugins list: #{plugins.keys.inspect}"
 
 default.elasticsearch[:plugins] = plugins
 default.elasticsearch[:plugins_mandatory] ||= []

--- a/attributes/proxy.rb
+++ b/attributes/proxy.rb
@@ -22,3 +22,7 @@ default.elasticsearch[:nginx][:passwords_file] = "#{node.elasticsearch[:conf_pat
 # Set this to `true` if you want to use a tool like BigDesk
 #
 default.elasticsearch[:nginx][:allow_cluster_api] = false
+
+# Other Nginx proxy settings
+#
+default.elasticsearch[:nginx][:client_max_body_size] = "50M"

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -62,6 +62,12 @@ cloud.node.auto_attributes: true
 cloud.aws.access_key: '<%= node.elasticsearch[:cloud][:aws][:access_key] %>'
 cloud.aws.secret_key: '<%= node.elasticsearch[:cloud][:aws][:secret_key] %>'
 <% end %>
+<% if node.elasticsearch[:cloud][:aws][:region] %>
+cloud.aws.region: '<%= node.elasticsearch[:cloud][:aws][:region] %>'
+<% end %>
+<% if node.elasticsearch[:cloud][:ec2][:endpoint] %>
+cloud.aws.ec2.endpoint: '<%= node.elasticsearch[:cloud][:ec2][:endpoint] %>'
+<% end %>
 
 <% if node.elasticsearch[:gateway][:type] %>
 ################################## Persistence ##################################

--- a/templates/default/elasticsearch_proxy.conf.erb
+++ b/templates/default/elasticsearch_proxy.conf.erb
@@ -1,6 +1,7 @@
 server {
   listen   <%= node.elasticsearch[:nginx][:port] %>;
   server_name  elasticsearch;
+  client_max_body_size <%= node.elasticsearch[:nginx][:client_max_body_size] %>;
 
   error_log   <%= node.elasticsearch[:nginx][:log_dir] %>/elasticsearch-errors.log;
   access_log  <%= node.elasticsearch[:nginx][:log_dir] %>/elasticsearch.log;


### PR DESCRIPTION
The current configuration templating leaves out many very useful settings.  I am submitting this pull request to shore up some holes that might make the cookbook far more useful to folks in different environments.  Included in these commits are the following:
- Network configurations including bind addresses and tcp port 
- HTTP configurations including port and max_content_length
- Multicast discovery that plays nicely with the aforementioned bind addresses.  You can easily control which network you do your multicast discovery on and even if you are in an env with cluster nodes that span multiple internal networks.  Works very well in production.
- Persistence gateway configuration thresholds are now tuneable
- JMX can be turned on or off as needed
- Logging thresholds are now tuneable for Slow Log and GC Log
- Recovery Throttling is now configurable.

I hope this helps everyone else out as much as it has helped us.
