### PR TITLE
Change execution of monitrc

### DIFF
--- a/recipes/monit.rb
+++ b/recipes/monit.rb
@@ -2,7 +2,7 @@
 #
 begin
   monitrc "elasticsearch" do
-    pidfile "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node_name].to_s.gsub(/\W/, '_')}.pid"
+    variables :pidfile => "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node_name].to_s.gsub(/\W/, '_')}.pid"
     template_cookbook "elasticsearch"
   end
 rescue Exception => e


### PR DESCRIPTION
This fixes #29 by changing the call to `monitrc` definition to correctly pass `template_cookbook` for use when the elasticsearch cookbook is not the primary one being executed.
