### PR TITLE
Do not use the '-' flag to su since it create a login shell. Doing that

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -32,7 +32,7 @@ start() {
     fi
 
     echo -e "\033[1mStarting elasticsearch...\033[0m"
-    su - <%= node[:elasticsearch][:user] %> -m -c "ES_INCLUDE=$ES_INCLUDE /usr/local/bin/elasticsearch -p $PIDFILE"
+    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE /usr/local/bin/elasticsearch -p $PIDFILE"
 
     return $?
 }


### PR DESCRIPTION
will prevent the environment from beeing inherited unless you also use '-m'.

But using '-' and '-m' when running bash will cause the launched shell to
try to read $HOME/.bash_profile since $HOME still refers to the home
directory of root and teh elasticsearch user does not have read access there.

A simple solution is to omit '-' and '-m'. The program will still run under
the elasticsearch user but will inherit environment variables and not
print an error message.
