### PR TITLE
Allow Berkshelf to handle cookbook loading

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -192,7 +192,6 @@ Vagrant::Config.run do |config|
       # Provision the machine with Chef Solo
       #
       box_config.vm.provision :chef_solo do |chef|
-        chef.cookbooks_path    = ['..', './tmp/cookbooks']
         chef.data_bags_path    = './tmp/data_bags'
         chef.provisioning_path = '/etc/vagrant-chef'
         chef.log_level         = :debug


### PR DESCRIPTION
In #56 I documented an issue I had that turned out to be another chef environment leaking into the elasticsearch tests.  It was from specifying '..' as a cookbook path in the Vagrantfile.

It seems to me that we should just allow Berkshelf to handle all of the cookbook loading and remove the `chef.cookbooks_path` setting altogether.

With this change, all tests pass on master in my environment.
