### PR TITLE
Sort logging config to prevent rewrite & restart

### DIFF
--- a/templates/default/logging.yml.erb
+++ b/templates/default/logging.yml.erb
@@ -1,6 +1,6 @@
 rootLogger: INFO, console, file
 
-<% node.elasticsearch[:logging].each do |key, value| %>
+<% node.elasticsearch[:logging].sort.each do |key, value| %>
 logger.<%= key %>: <%= value %>
 <% end %>
 


### PR DESCRIPTION
In practice, <% node.elasticsearch[:logging].each do |key, value| %> seems to have a non-deterministic order and thus Chef will trigger a restart of the ElasticSearch server every time the chef-client is run (10.18.2). We run on a 30-minute chef cycle and were seeing periodic restarts of the server every 30-120 minutes.

I've added a sort to the logging.yml.erb template to prevent this.

```
diff -u /var/lib/chef/usr/local/etc/elasticsearch/logging.yml.chef-20130221071355 /var/lib/chef/usr/local/etc/elasticsearch/logging.yml.chef-20130221075603
--- /var/lib/chef/usr/local/etc/elasticsearch/logging.yml.chef-20130221071355   2013-02-21 06:59:31.000000000 +0000
+++ /var/lib/chef/usr/local/etc/elasticsearch/logging.yml.chef-20130221075603   2013-02-21 07:43:55.000000000 +0000
@@ -2,8 +2,8 @@

 logger.index.search.slowlog: TRACE, index_search_slow_log_file
 logger.action: DEBUG
-logger.com.amazonaws: WARN
 logger.index.indexing.slowlog: TRACE, index_indexing_slow_log_file
+logger.com.amazonaws: WARN

 additivity:
   index.search.slowlog: false
```
