### PR TITLE
Update templates/default/elasticsearch.yml.erb

### DIFF
--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -134,6 +134,6 @@ jmx.domain: elasticsearch
 
 ################################## Custom #####################################
 
-<% node.elasticsearch[:custom_config].sort.each do |key, value| %>
+<% (node.elasticsearch[:custom_config] || {}).sort.each do |key, value| %>
 <%= key %>: <%= value %>
 <% end %>


### PR DESCRIPTION
Fixes crash when elasticsearch[:custom_config] is not set.
