### PR TITLE
Add support for EC2 discovery type's instance tag constraints.

### DIFF
--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -21,4 +21,9 @@ default.elasticsearch[:cloud][:aws][:secret_key]     = ( aws['cloud']['aws']['se
 default.elasticsearch[:cloud][:aws][:region]         = ( aws['cloud']['aws']['region']         rescue nil )
 default.elasticsearch[:cloud][:ec2][:endpoint]       = ( aws['cloud']['ec2']['endpoint']       rescue nil )
 
+discovery_tags = ( aws['discovery']['ec2']['tag'] rescue [] )
+discovery_tags.each do |tag_name, tag_value|
+  default.elasticsearch[:discovery][:ec2][:tag][tag_name] = tag_value
+end
+
 default.elasticsearch[:cloud][:node][:auto_attributes] = true

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -95,6 +95,10 @@
 <%= print_value 'discovery.ec2.availability_zones' -%>
 <%= print_value 'discovery.ec2.any_group' -%>
 <%= print_value 'discovery.ec2.ping_timeout' -%>
+<%- if node.elasticsearch[:discovery][:ec2][:tag] -%><% node.elasticsearch[:discovery][:ec2][:tag].sort.each do |key, value| %>
+'discovery.ec2.tag.<%= key %>': <%= value %>
+<% end %>
+<%- end -%>
 <%- end -%>
 
 ################################## Slow Log ###################################


### PR DESCRIPTION
The `aws` data bag can now have a structure at `discovery.ec2.tag` that contains EC2 instance tag values keyed by tag name. Any tag specified will be required for an EC2 instance to be discoverable by the plugin.
