### PR TITLE
Print `discovery.type` in elasticsearch.yml if available.

### DIFF
--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -78,6 +78,9 @@
 
 ################################## Discovery ##################################
 
+<%= print_value 'discovery.type' -%>
+
+# Zen Discovery
 <%= print_value 'discovery.zen.minimum_master_nodes' -%>
 <%= print_value 'discovery.zen.ping.timeout' -%>
 <%= print_value 'discovery.zen.ping.multicast.enabled' -%>


### PR DESCRIPTION
Printing `discovery.type` in the elasticsearch configuration allows the `ec2` type to be enabled by a data bag or other configuration by means of the `aws` recipe.
