### PR TITLE
Always switch databag attributes by environment

### DIFF
--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -3,7 +3,7 @@ include_attribute 'elasticsearch::plugins'
 
 # Load configuration and credentials from data bag 'elasticsearch/aws' -
 #
-aws = Chef::DataBagItem.load('elasticsearch', 'aws') rescue {}
+aws = Chef::DataBagItem.load('elasticsearch', 'aws')[node.chef_environment] rescue {}
 # ----------------------------------------------------------------------
 
 # To use the AWS discovery, you have to properly set up the configuration,

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 # Load settings from data bag 'elasticsearch/settings'
 #
-settings = Chef::DataBagItem.load('elasticsearch', 'settings') rescue {}
+settings = Chef::DataBagItem.load('elasticsearch', 'settings')[node.chef_environment] rescue {}
 Chef::Log.debug "Loaded settings: #{settings.inspect}"
 
 # Initialize the node attributes with node attributes merged with data bag attributes

--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -1,6 +1,6 @@
 Chef::Log.debug "Attempting to load plugin list from the databag..."
 
-plugins = Chef::DataBagItem.load('elasticsearch', 'plugins').to_hash['plugins'] rescue {}
+plugins = Chef::DataBagItem.load('elasticsearch', 'plugins')[node.chef_environment].to_hash['plugins'] rescue {}
 
 Chef::Log.debug "Plugins list: #{plugins.keys.inspect}"
 

--- a/attributes/proxy.rb
+++ b/attributes/proxy.rb
@@ -3,7 +3,7 @@ include_attribute "elasticsearch::nginx"
 
 # Try to load data bag item 'elasticsearch/aws' ------------------
 #
-users = Chef::DataBagItem.load('elasticsearch', 'users')['users'] rescue []
+users = Chef::DataBagItem.load('elasticsearch', 'users')[node.chef_environment]['users'] rescue []
 # ----------------------------------------------------------------
 
 # === NGINX ===


### PR DESCRIPTION
Consistency among databag loading and switching by environment as discussed in #54. I'm good with either approach, but just wanted to point out that we're using this approach with chef-server on 11.4 and it works just fine.
