### PR TITLE
Fix custom installation directory

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,10 +65,8 @@ end
 
 # Download, extract, symlink the elasticsearch libraries and binaries
 #
-ark_prefix_root = node.elasticsearch[:dir]
-ark_prefix_root ||= node.ark[:prefix_root]
-ark_prefix_home = node.elasticsearch[:dir]
-ark_prefix_home ||= node.ark[:prefix_home]
+ark_prefix_root = node.elasticsearch[:dir] || node.ark[:prefix_root]
+ark_prefix_home = node.elasticsearch[:dir] || node.ark[:prefix_home]
 
 ark "elasticsearch" do
   url   node.elasticsearch[:download_url]


### PR DESCRIPTION
If you set a custom installation directory using the `:dir` attribute, the cookbook still installs ElasticSearch in `/usr/local/`. This is because the call to `ark` that downloads and installs ElasticSearch doesn't include the necessary parameters to actually place the unpacked files in a custom location.

This pull request updates the `default` cookbook to properly configure `ark` when using a custom directory.
