### PR TITLE
Set missing s3 bucket name in elasticsearch.yml.erb

### DIFF
--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -65,6 +65,9 @@
 ################################### Gateway ###################################
 
 <%= print_value 'gateway.type', node.elasticsearch[:gateway][:type] -%>
+<%- if node.elasticsearch[:gateway][:s3][:bucket] -%>
+<%= print_value 'gateway.s3.bucket', node.elasticsearch[:gateway][:s3][:bucket] -%>
+<%- end -%>
 <%= print_value 'gateway.recover_after_nodes' -%>
 <%= print_value 'gateway.recover_after_time' -%>
 <%= print_value 'gateway.expected_nodes' -%>


### PR DESCRIPTION
Current version doesn't work with s3 gateway.
The cookbook doesn't set the bucket name and elasticsearch fail with:

```
Initialization Failed ...
1) ElasticSearchIllegalArgumentException[No bucket defined for s3 gateway]
```

This fix set the bucket name in elasticsearch.yml
