### PR TITLE
Use start-stop-daemon to start when on debian family so we can background correctly

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -32,8 +32,7 @@ start() {
     fi
 
     echo -e "\033[1mStarting elasticsearch...\033[0m"
-    <% case node.platform_family do %>
-    <% when 'debian' %>
+    <% if node.platform_family == 'debian' %>
     ES_INCLUDE=$ES_INCLUDE start-stop-daemon --background --start --quiet --pidfile $PIDFILE --chuid <%= node[:elasticsearch][:user] %> --exec /usr/local/bin/elasticsearch -- -p $PIDFILE
     <% else %>
     su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE /usr/local/bin/elasticsearch -p $PIDFILE"


### PR DESCRIPTION
Initial bootstraps would start the service, but would not leave the service running (service would die after provision completed and ssh connection severed). Updates to use start-stop-daemon to start on debian platform families. Uses the `--background` option to force the process to properly detach. (may be loosely related to #32)
