### PR TITLE
Gemfile gem versions to fix "testing with Vagrant"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'pry'
-gem 'chef'
-gem 'vagrant'
-gem 'berkshelf'
+gem 'chef', '10.16.2'
+gem 'vagrant', '1.0.7'
+gem 'berkshelf', '1.1.5'
 gem 'test-kitchen'
 
 gem 'activesupport'


### PR DESCRIPTION
As it currently stands, the Vagrant file is only compatible with RubyGems distribution of Vagrant up to version 1.0.7. This means that other dependencies need to be locked to specific versions or the whole thing fails.

What would be the drawback of adding these versions to the Gemfile?
