### PR TITLE
Typo in attributes for elasticsearch aws attributes

### DIFF
--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -23,7 +23,7 @@ aws = Chef::DataBagItem.load('elasticsearch', 'aws')[node.chef_environment] resc
 # Instead of using AWS access tokens, you can create the instance with a IAM role.
 # See: http://aws.amazon.com/iam/faqs/#How_do_i_get_started_with_IAM_roles_for_EC2_instances
 
-default.elasticsearch['plugins']['elasticsearch-cloud-aws']['version'] = '1.12.0'
+default.elasticsearch['plugins']['elasticsearch/elasticsearch-cloud-aws']['version'] = '1.12.0'
 
 # === AWS ===
 # AWS configuration is set based on data bag values.


### PR DESCRIPTION
I was trying to deploy to an aws node, and noticed a typo.

OUTPUT BELOW:

[Mon, 01 Jul 2013 19:06:44 -0400] INFO: Processing ruby_block[Install plugin: elasticsearch-cloud-aws] action create (elasticsearch::plugins line 35)
-> Installing elasticsearch-cloud-aws/1.11.0...
Trying https://github.com/elasticsearch-cloud-aws/1.11.0/zipball/master... (assuming site plugin)
Failed to install elasticsearch-cloud-aws/1.11.0, reason: failed to download out of all possible locations..., use -verbose to get detailed information

vs.

[Mon, 01 Jul 2013 19:08:01 -0400] INFO: Processing ruby_block[Install plugin: elasticsearch/elasticsearch-cloud-aws] action create (elasticsearch::plugins line 35)
-> Installing elasticsearch/elasticsearch-cloud-aws/1.11.0...
Trying http://download.elasticsearch.org/elasticsearch/elasticsearch-cloud-aws/elasticsearch-cloud-aws-1.11.0.zip...
Downloading ............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................DONE
Installed cloud-aws
[Mon, 01 Jul 2013 19:08:05 -0400] INFO: ruby_block[Install plugin: elasticsearch/elasticsearch-cloud-aws] called
