### PR TITLE
Fix discovery.ec2.groups typo in the aws attributes file

### DIFF
--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -31,7 +31,7 @@ default.elasticsearch['plugins']['elasticsearch-cloud-aws']['version'] = '1.12.0
 #
 default.elasticsearch[:gateway][:type]               = ( aws['gateway']['type']                rescue nil )
 default.elasticsearch[:discovery][:type]             = ( aws['discovery']['type']              rescue nil )
-default.elasticsearch[:discovery][:ec2][:groups]     = ( aws['discovery']['ec2']['group']      rescue nil )
+default.elasticsearch[:discovery][:ec2][:groups]     = ( aws['discovery']['ec2']['groups']     rescue nil )
 default.elasticsearch[:discovery][:ec2][:tag]        = ( aws['discovery']['ec2']['tag']        rescue {} )
 
 default.elasticsearch[:cloud][:aws][:access_key]     = ( aws['cloud']['aws']['access_key']     rescue nil )


### PR DESCRIPTION
In the attributes/aws.rb file, the attribute is incorrectly set to use group. 

The template 'elasticsearch.yml.erb' also expects it to be "groups":

<%- if node.elasticsearch[:cloud] -%>
...
<%= print_value 'discovery.ec2.groups' -%>

Thank you. 
