### PR TITLE
Fix the stop function in init script

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -54,8 +54,17 @@ stop() {
       fi
 
       # KILL PROCESS
+      pid=$(cat $PIDFILE)
       su <%= node[:elasticsearch][:user] %> -m -c "kill $(cat $PIDFILE)"
       r=$?
+
+      timeout=0
+      while [ $(ps -p $pid | wc -l ) -gt '1' ]; do
+        (( timeout ++))
+        if [ $timeout -gt '30' ]; then return; fi
+        sleep 1
+      done;
+
       timeout=0
       while [ -f $PIDFILE  ]; do
         echo -n '.'


### PR DESCRIPTION
In some case the process of elasticsearch changes to 
1017     23661 17.0  0.0      0     0 ?        Zl   Jun25 5181:59 [java] <defunct> 
after executing the line so <%= node [: elasticsearch][:user] %> -m -c "kill $(cat $PIDFILE)".

The process is still there for a while but ps aux | grep 'java' | grep -e "es.pidfile" in the restart() function thinks the process has already been killed and tries to start, and start fails because the memory is not enough to create the jvm heap, and chef log shows "service [elasticsearch] restarted].

Need to make sure the pid does get killed in the stop().
