### PR TITLE
Added a section to the init script that creates the pidfile dir if it ha...

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -18,6 +18,12 @@ ES_INCLUDE='<%= node.elasticsearch[:path][:conf] %>/elasticsearch-env.sh'
 CHECK_PID_RUNNING=$(ps ax | grep 'java' | grep -e "es.pidfile=$PIDFILE" | sed 's/^\s*\([0-9]*\)\s.*/\1/')
 
 start() {
+    # CREATE PID DIR IF NECESSARY
+    PID_DIR=`dirname $PIDFILE`
+    if [ ! -d $PID_DIR ]; then
+        mkdir $PID_DIR
+        chown <%= node[:elasticsearch][:user] %>:<%= node[:elasticsearch][:group] %> $PID_DIR
+    fi
     if [ -f $PIDFILE ]; then
       # PIDFILE EXISTS -- ES RUNNING?
       echo -e "\033[31;1mPID file found in $PIDFILE, elasticsearch already running?\033[0m"


### PR DESCRIPTION
On some systems the /var directory is cleared on restart, which causes the elasticsearch startup script to fail silently. (issue #108)
