### PR TITLE
Replaces `bash` with `file` resource to adjust file descriptor limits via `limits.d`

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,20 +94,13 @@ bash "enable user limits" do
   not_if { ::File.read("/etc/pam.d/su").match(/^session    required   pam_limits\.so/) }
 end
 
-bash "increase limits for the elasticsearch user" do
-  user 'root'
+log "increase limits for the elasticsearch user"
 
-  code <<-END.gsub(/^    /, '')
-    echo '#{node.elasticsearch.fetch(:user, "elasticsearch")}     -    nofile    #{node.elasticsearch[:limits][:nofile]}'  >> /etc/security/limits.conf
-    echo '#{node.elasticsearch.fetch(:user, "elasticsearch")}     -    memlock   #{node.elasticsearch[:limits][:memlock]}' >> /etc/security/limits.conf
+file "/etc/security/limits.d/10-elasticsearch.conf" do
+  content <<-END.gsub(/^    /, '')
+    #{node.elasticsearch.fetch(:user, "elasticsearch")}     -    nofile    #{node.elasticsearch[:limits][:nofile]}
+    #{node.elasticsearch.fetch(:user, "elasticsearch")}     -    memlock   #{node.elasticsearch[:limits][:memlock]}
   END
-
-  not_if do
-    file = ::File.read("/etc/security/limits.conf")
-    file.include?("#{node.elasticsearch.fetch(:user, "elasticsearch")}     -    nofile    #{node.elasticsearch[:limits][:nofile]}") \
-    &&           \
-    file.include?("#{node.elasticsearch.fetch(:user, "elasticsearch")}     -    memlock   #{node.elasticsearch[:limits][:memlock]}")
-  end
 end
 
 # Create file with ES environment variables


### PR DESCRIPTION
While reading the recommendations found [here](http://asquera.de/opensource/2012/11/25/elasticsearch-pre-flight-checklist/#file-descriptors) I thought that it would be a good idea to use `limits.d` instead of hacking the `limits.conf` file directly.

This way Chef handles the idempotency itself and we can drop the custom (and hard to read) `not_if` magic.

The result is the following file:

```
# cat /etc/security/limits.d/10-elasticsearch.conf
elasticsearch     -    nofile    4000
elasticsearch     -    memlock   unlimited
```

Tested on Vagrant with Debian 6 by removing the two lines from `/etc/security/limits.conf` and restarting the machine.

Calling `ulimit -Hn` showed the expected value.
