### PR TITLE
Use single forward sign `>` to create missing file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,7 +77,7 @@ the information in an "elasticsearch" _data bag_:
           "ec2"     : { "security_group": "elasticsearch" }
         }
       }
-    }' >> ./data_bags/elasticsearch/aws.json
+    }' > ./data_bags/elasticsearch/aws.json
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Do not forget to upload the data bag to the _Chef_ server:
@@ -138,7 +138,7 @@ Usernames and passwords may be stored in a data bag `elasticsearch/users`:
         ]
       }
     }
-    ' >> ./data_bags/elasticsearch/users.json
+    ' > ./data_bags/elasticsearch/users.json
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Again, do not forget to upload the data bag to the _Chef_ server:


### PR DESCRIPTION
In order to APPEND to an existing file the double signs `>>` assume that there is an existing file.

In our example there is no file and the command fails.

With this change the command creates the missing file and succeeds.
