### PR TITLE
added support for bin path, moved pid dir into path mash

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,13 +27,13 @@ default.elasticsearch[:node][:name]    = node.name
 #
 default.elasticsearch[:dir]       = "/usr/local"
 default.elasticsearch[:user]      = "elasticsearch"
-
+default.elasticsearch[:path][:bin]  = "#{node.elasticsearch[:dir]}/bin"
 default.elasticsearch[:path][:conf] = "/usr/local/etc/elasticsearch"
 default.elasticsearch[:path][:data] = "/usr/local/var/data/elasticsearch"
 default.elasticsearch[:path][:logs] = "/usr/local/var/log/elasticsearch"
+default.elasticsearch[:path][:pid]  = "/usr/local/var/run/elasticsearch"
 
-default.elasticsearch[:pid_path]  = "/usr/local/var/run/elasticsearch"
-default.elasticsearch[:pid_file]  = "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node][:name].to_s.gsub(/\W/, '_')}.pid"
+default.elasticsearch[:pid_file]  = "#{node.elasticsearch[:path][:pid]}/#{node.elasticsearch[:node][:name].to_s.gsub(/\W/, '_')}.pid"
 
 # === MEMORY
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email "karmi@karmi.cz"
 license          "Apache"
 description      "Installs and configures elasticsearch"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.markdown'))
-version          "0.3.3"
+version          "0.3.4"
 
 depends 'ark'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,13 +32,20 @@ bash "remove the elasticsearch user home" do
 end
 
 # Create ES directories
-#
-[ node.elasticsearch[:path][:conf], node.elasticsearch[:path][:logs], node.elasticsearch[:pid_path] ].each do |path|
+
+[:conf, :pid, :data, :logs].each do |name|
+  path=node.elasticsearch[:path][name]
   directory path do
     owner node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
     recursive true
     action :create
   end
+end
+# don't want bins owned by non-root user
+directory node.elasticsearch[:path][:bin] do
+  owner "root" and group "root" and mode "0755"
+  recursive true
+  action    :create
 end
 
 # Create data path directories

--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -40,9 +40,9 @@ start() {
 
     echo -e "\033[1mStarting elasticsearch...\033[0m"
     <% if node.platform_family == 'debian' %>
-    ES_INCLUDE=$ES_INCLUDE start-stop-daemon --background --start --quiet --pidfile $PIDFILE --chuid <%= node[:elasticsearch][:user] %> --exec /usr/local/bin/elasticsearch -- -p $PIDFILE
+    ES_INCLUDE=$ES_INCLUDE start-stop-daemon --background --start --quiet --pidfile $PIDFILE --chuid <%= node[:elasticsearch][:user] %> --exec <%= node.elasticsearch[:path][:bin] -%>/elasticsearch -- -p $PIDFILE
     <% else %>
-    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE /usr/local/bin/elasticsearch -p $PIDFILE"
+    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE <%= node.elasticsearch[:path][:bin] -%>/elasticsearch -p $PIDFILE"
     <% end %>
 
     return $?


### PR DESCRIPTION
/usr/local/bin was hardcoded in the init template
Moved all directories into the :path mash and added support for an outboard :bin directory