### PR TITLE
Install elasticsearch-cloud-aws plugin only if needed

### DIFF
--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -6,6 +6,6 @@ directory "#{node.elasticsearch[:dir]}/elasticsearch-#{node.elasticsearch[:versi
 end
 
 node[:elasticsearch][:plugins].each do | name, config |
-  next if name == 'elasticsearch-cloud-aws' && !node.recipe?('aws')
+  next if name == 'elasticsearch/elasticsearch-cloud-aws' && !node.recipe?('aws')
   install_plugin name, config
 end


### PR DESCRIPTION
`attributes/aws` defines `elasticsearch/elasticsearch-cloud-aws` key for plugins hash whilst `recipes/plugins.rb` tries to match it as `elasticsearch-cloud-aws`.
