### PR TITLE
update templates to support non-standard http port

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ node.normal[:elasticsearch]  ||= {}
 node.normal[:elasticsearch]    = DeepMerge.merge(node.default[:elasticsearch].to_hash, node.normal[:elasticsearch].to_hash)
 node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_hash, settings.to_hash)
 
+
 # === VERSION AND LOCATION
 #
 default.elasticsearch[:version]       = "0.90.3"
@@ -65,6 +66,10 @@ default.elasticsearch[:gateway][:type] = 'local'
 default.elasticsearch[:gateway][:expected_nodes] = 1
 
 default.elasticsearch[:thread_stack_size] = "256k"
+
+# === PORT
+#
+default.elasticsearch[:http][:port] = 9200
 
 # === CUSTOM CONFIGURATION
 #

--- a/templates/default/elasticsearch.conf.erb
+++ b/templates/default/elasticsearch.conf.erb
@@ -12,11 +12,11 @@ check process elasticsearch with pidfile <%= node.elasticsearch[:pid_file] %>
 
 <% if node.monit[:notify_email] %>
 check host elasticsearch_connection with address 0.0.0.0
-  if failed url http://0.0.0.0:9200/ with timeout 15 seconds then alert
+  if failed url http://0.0.0.0:<%= node.elasticsearch[:http][:port] %>/ with timeout 15 seconds then alert
   group elasticsearch
 
 check host elasticsearch_cluster_health with address 0.0.0.0
-  if failed url http://0.0.0.0:9200/_cluster/health
+  if failed url http://0.0.0.0<%= node.elasticsearch[:http][:port] %>/_cluster/health
      and content == 'green'
      with timeout 60 seconds
      then alert

--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -94,11 +94,11 @@ status() {
 
   # RUNNING
   if [[ $pid && -d "/proc/$pid" ]]; then
-    version=$(curl -s 'http://localhost:9200' | ruby -rubygems -e 'require "json"; print JSON.parse(STDIN.read)["version"]["number"]')
+    version=$(curl -s 'http://localhost:<%= node.elasticsearch[:http][:port] %>' | ruby -rubygems -e 'require "json"; print JSON.parse(STDIN.read)["version"]["number"]')
     echo -e "\033[1;37;46melasticsearch $version running with PID $pid\033[0m"
     # VERBOSE
     if [[ $pid && $1 == '-v' || $1 == '--verbose' ]]; then
-      curl -s 'http://localhost:9200/_cluster/nodes/<%= node.elasticsearch[:node][:name] %>?os&process&jvm&network&transport&settings&pretty' | \
+      curl -s 'http://localhost:<%= node.elasticsearch[:http][:port] %>/_cluster/nodes/<%= node.elasticsearch[:node][:name] %>?os&process&jvm&network&transport&settings&pretty' | \
       ruby -rubygems -e '
         begin
           require "json"; h = JSON.parse(STDIN.read); id, node = h["nodes"].first;

--- a/templates/default/elasticsearch_proxy.conf.erb
+++ b/templates/default/elasticsearch_proxy.conf.erb
@@ -23,7 +23,7 @@ server {
 <% end %>
 
     # Pass requests to ElasticSearch
-    proxy_pass http://<%= node.elasticsearch.network.host rescue 'localhost' %>:<%= node.elasticsearch.http.port rescue 9200 %>;
+    proxy_pass http://<%= node.elasticsearch.network.host rescue 'localhost' %>:<%= node.elasticsearch[:http][:port] %>;
     proxy_redirect off;
 
     proxy_set_header  X-Real-IP  $remote_addr;
@@ -47,7 +47,7 @@ server {
   location /status {
     proxy_method HEAD;
     proxy_intercept_errors on;
-    proxy_pass http://localhost:9200/;
+    proxy_pass http://localhost:<%= node.elasticsearch[:http][:port] %>/;
   }
 <% end %>
 


### PR DESCRIPTION
The templates in the cookbook did not support elastic on a non-standard http port. 
