### PR TITLE
Update to 0.90.4

### DIFF
--- a/attributes/deb.rb
+++ b/attributes/deb.rb
@@ -1,2 +1,2 @@
-default.elasticsearch[:deb_url] = "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.4.deb"
-default.elasticsearch[:deb_sha] = "5b11deb310aae745605e933a615e288a759d56277db88fe90cfcd1816c7f3a60"
+default.elasticsearch[:deb_url] = "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.5.deb"
+default.elasticsearch[:deb_sha] = "d25cdc971b1ef2393a620731137bae16e0d1107d49294b11c14634da0f1bb330"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_
 
 # === VERSION AND LOCATION
 #
-default.elasticsearch[:version]       = "0.90.4"
+default.elasticsearch[:version]       = "0.90.5"
 default.elasticsearch[:host]          = "http://download.elasticsearch.org"
 default.elasticsearch[:repository]    = "elasticsearch/elasticsearch"
 default.elasticsearch[:filename]      = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"

--- a/attributes/rpm.rb
+++ b/attributes/rpm.rb
@@ -1,2 +1,2 @@
-default.elasticsearch[:rpm_url] = "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.4.noarch.rpm"
-default.elasticsearch[:rpm_sha] = "9bf9a79588554b9e397e81aec22a7254d79bb9f730d3342df7ddb5f1cef0338d"
+default.elasticsearch[:rpm_url] = "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.5.noarch.rpm"
+default.elasticsearch[:rpm_sha] = "a0d8b4cba30838f2ba09d960baf12e7c1aba6fd373c220e5f50416fc1c35e71d"

--- a/tests/plugins_test.rb
+++ b/tests/plugins_test.rb
@@ -6,7 +6,7 @@ describe_recipe 'elasticsearch::plugins' do
 
   it "creates the file in plugins" do
     if node.recipes.include?("elasticsearch::plugins")
-      file("/usr/local/elasticsearch/plugins/paramedic/index.html").must_exist.with(:owner, 'elasticsearch')
+      file("/usr/local/elasticsearch/plugins/paramedic/_site/index.html").must_exist.with(:owner, 'elasticsearch')
     end
   end if Chef::VERSION > '10.14'
 


### PR DESCRIPTION
0.90.4 was released earlier today, updating the version numbers as SHA256 checksums.  Check out the commit message for `1d22fa3` for an explanation of how the SHA's were updated (I couldn't replicate your checksums).
