### PR TITLE
check for existing binary when skipping install

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -86,8 +86,9 @@ ark "elasticsearch" do
   not_if do
     link   = "#{node.elasticsearch[:dir]}/elasticsearch"
     target = "#{node.elasticsearch[:dir]}/elasticsearch-#{node.elasticsearch[:version]}"
+    binary = "#{target}/bin/elasticsearch"
 
-    ::File.directory?(link) && ::File.symlink?(link) && ::File.readlink(link) == target
+    ::File.directory?(link) && ::File.symlink?(link) && ::File.readlink(link) == target && ::File.exists?(binary)
   end
 end
 


### PR DESCRIPTION
When deciding whether to skip installation, it's probably safer to not only check for the es directories to exist, since they could have been created by the plugins recipe as well. This PR adds a check for the existence of the es binary to the not_if condition list.
