### PR TITLE
fix monit check for cluster health (add missing colon)

### DIFF
--- a/templates/default/elasticsearch.conf.erb
+++ b/templates/default/elasticsearch.conf.erb
@@ -16,7 +16,7 @@ check host elasticsearch_connection with address 0.0.0.0
   group elasticsearch
 
 check host elasticsearch_cluster_health with address 0.0.0.0
-  if failed url http://0.0.0.0<%= node.elasticsearch[:http][:port] %>/_cluster/health
+  if failed url http://0.0.0.0:<%= node.elasticsearch[:http][:port] %>/_cluster/health
      and content == 'green'
      with timeout 60 seconds
      then alert


### PR DESCRIPTION
a colon was missing between host and port number
