### PR TITLE
Adding http.host setting

### DIFF
--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -59,6 +59,7 @@
 <%= print_value 'network.host' -%>
 <%= print_value 'transport.tcp.port' -%>
 <%= print_value 'transport.tcp.compress' -%>
+<%= print_value 'http.host' -%>
 <%= print_value 'http.port' -%>
 <%= print_value 'http.max_content_length' -%>
 <%= print_value 'http.enabled' -%>


### PR DESCRIPTION
Sometimes it's desired to have a different http.host from network.host, like having public host for transport and localhost for hiding elasticsearch behind proxy
