### PR TITLE
allow additional java environment variables

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,6 +67,8 @@ default.elasticsearch[:gateway][:expected_nodes] = 1
 
 default.elasticsearch[:thread_stack_size] = "256k"
 
+default.elasticsearch[:env_opts] = ""
+
 # === PORT
 #
 default.elasticsearch[:http][:port] = 9200

--- a/templates/default/elasticsearch-env.sh.erb
+++ b/templates/default/elasticsearch-env.sh.erb
@@ -26,4 +26,5 @@ ES_JAVA_OPTS="
   -Dcom.sun.management.jmxremote.port=3333
   -Djava.rmi.server.hostname=<%= node[:ipaddress] %>
 <% end %>
+  <%= node.elasticsearch[:env_opts] %>
 "


### PR DESCRIPTION
I have the need to pass additional params to process when starting. 

For example I needed to introduce -DSTATS_DPREFIX="" for use in one of our custom plugins. It would be nice to allow any number of variables to be added to the environment when starting elasticsearch.
