### PR TITLE
Only template authentication config if users specified

### DIFF
--- a/templates/default/elasticsearch_proxy.conf.erb
+++ b/templates/default/elasticsearch_proxy.conf.erb
@@ -37,9 +37,11 @@ server {
     add_header Access-Control-Allow-Headers 'X-Requested-With, Content-Type';
     add_header Access-Control-Allow-Credentials true;
 
+<% unless node.elasticsearch[:nginx][:users].empty? %>
     # Authorize access
     auth_basic           "ElasticSearch";
     auth_basic_user_file <%= node.elasticsearch[:nginx][:passwords_file] %>;
+<% end %>
 
   }
 


### PR DESCRIPTION
If the config is added but no username/passwords exist in the file, authentication is impossible as there are no valid credentials.  This adds the same guard that sits around the templating of the passwords file to the authentication section of the proxy.
