### PR TITLE
update example data bag to correctly reflect discovery attributes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -148,11 +148,13 @@ the information in an "elasticsearch" _data bag_:
     echo '{
       "id" : "aws",
       "_default" : {
-        "discovery" : { "type": "ec2" },
-
+        "discovery" : { 
+                        "type": "ec2",
+                        "ec2" : { "groups": "elasticsearch" }
+        },
         "cloud"   : {
           "aws"     : { "access_key": "YOUR ACCESS KEY", "secret_key": "YOUR SECRET ACCESS KEY" },
-          "ec2"     : { "groups": "elasticsearch" }
+         
         }
       }
     }' > ./data_bags/elasticsearch/aws.json


### PR DESCRIPTION
hi!
i ran into this when trying to deploy a cluster using aws discovery, the template actually looks for the security groups and tags under the `node[:elasticsearch][:discovery]` attribute, not the `:cloud` one.
