### PR TITLE
Fixed static path in init template and replaced it with the installation...

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -33,9 +33,9 @@ start() {
 
     echo -e "\033[1mStarting elasticsearch...\033[0m"
     <% if node.platform_family == 'debian' %>
-    ES_INCLUDE=$ES_INCLUDE start-stop-daemon --background --start --quiet --pidfile $PIDFILE --chuid <%= node[:elasticsearch][:user] %> --exec /usr/local/bin/elasticsearch -- -p $PIDFILE
+    ES_INCLUDE=$ES_INCLUDE start-stop-daemon --background --start --quiet --pidfile $PIDFILE --chuid <%= node[:elasticsearch][:user] %> --exec  <%= node[:elasticsearch][:dir] %>/elasticsearch/bin/elasticsearch -- -p $PIDFILE
     <% else %>
-    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE /usr/local/bin/elasticsearch -p $PIDFILE"
+    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE <%= node[:elasticsearch][:dir] %>/elasticsearch/bin/elasticsearch -p $PIDFILE"
     <% end %>
 
     return $?


### PR DESCRIPTION
In case you just want the init script fixed without splitting the bin directory in a seperate mash. This one replaces the static "/usr/local" with the :dir mash
