### PR TITLE
support for systemd. also setting specific uid/gid

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,10 +24,18 @@ default.elasticsearch[:download_url]  = [node.elasticsearch[:host], node.elastic
 default.elasticsearch[:cluster][:name] = 'elasticsearch'
 default.elasticsearch[:node][:name]    = node.name
 
+# === SERVICE
+#
+# init_style options:
+# - initd
+# - systemd
+default.elasticsearch[:init_style] = 'initd'
+
 # === USER & PATHS
 #
 default.elasticsearch[:dir]       = "/usr/local"
 default.elasticsearch[:user]      = "elasticsearch"
+default.elasticsearch[:uid]       = nil  # set elasticsearch user to specific uid. nil for next available
 
 default.elasticsearch[:path][:conf] = "/usr/local/etc/elasticsearch"
 default.elasticsearch[:path][:data] = "/usr/local/var/data/elasticsearch"

--- a/templates/default/elasticsearch.service.erb
+++ b/templates/default/elasticsearch.service.erb
@@ -1,0 +1,16 @@
+# Dropped off by Chef
+
+[Unit]
+Description=ElasticSearch
+
+[Service]
+User=<%= node.elasticsearch[:user] %>
+Group=<%= node.elasticsearch[:user] %>
+Restart=on-failure
+LimitMEMLOCK=<%= node.elasticsearch[:limits][:memlock] %>
+LimitNOFILE=<%= node.elasticsearch[:limits][:nofile] %>
+Environment="ES_INCLUDE=<%= node.elasticsearch[:path][:conf] %>/elasticsearch-env.sh"
+ExecStart=<%= node.elasticsearch[:dir] %>/elasticsearch/bin/elasticsearch -f
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- this PR includes support for systemd units (`*.service file`). tested on fedora-19 but may work with any distro using systemd
- also added optional support for setting a specific uid/gid on the `elasticsearch` user