### PR TITLE
Updates to the EBS provider, use existing node data in place of attributes

### DIFF
--- a/libraries/create_ebs.rb
+++ b/libraries/create_ebs.rb
@@ -17,10 +17,11 @@ module Extensions
 
       block do
         require 'fog'
+        require 'open-uri'
         # get out region and instance_ID from the ohai node data - removes the reliance on open-uri and removes the possibility 
         # that we connect to the wrong region if the attribute is set wrong -TH
-        region      = node[:ec2][:placement_availability_zone].chop()
-        instance_id = node[:ec2][:instance_id]
+        region      = node[:ec2][:placement_availability_zone].chop() || node.elasticsearch[:cloud][:aws][:region] 
+        instance_id = node[:ec2][:instance_id] || open('http://169.254.169.254/latest/meta-data/instance-id'){|f| f.gets}
 
         Chef::Log.debug("Region: #{region}, instance ID: #{instance_id}")
 
@@ -49,7 +50,7 @@ module Extensions
           options = { :device                => ebs_device,
                       :size                  => params[:ebs][:size],
                       :delete_on_termination => params[:ebs][:delete_on_termination],
-                      :availability_zone     => node[:ec2][:placement_availability_zone], #use the node info to pick the AZ -TH
+                      :availability_zone     => server.availability_zone, 
                       :server                => server }
 
           options[:type] = params[:ebs][:type] if params[:ebs][:type]


### PR DESCRIPTION
Updates to the EBS provider, use existing node data in place of attributes and curls, also some comments and tidying. These changes will help prevent errors due to incorrectly set attributes and ensures the volume is created in the correct AZ as well as speeds up the convergence by removing the call to the metadata api

TODO - Wrap the aws variable assignment and rescue it .. the variable is assigned the failed connection results if there is a problem, which causes the rest of the process to fail (comments for troubleshooting inline)

I made these changes based on the following testing in the chef-shell:

$ chef-shell -z
chef > node.ec2.placement_availability_zone
 => "us-east-1a"
chef > instance_id = node[:ec2][:instance_id]
 => "i-XXXXXXXX"
chef > region = node[:ec2][:placement_availability_zone].chop()
 => "us-east-1"
chef > fog_options = { :provider => 'AWS', :region => region, :use_iam_profile => true }
 => {:provider=>"AWS", :region=>"us-east-1", :use_iam_profile=>true}
chef > aws = Fog::Compute.new(fog_options)
 => Blah
chef > aws.servers.get(instance_id)
 =>   <Fog::Compute::AWS::Server
    id="i-XXXXXXXX",
    ami_launch_index=0,
