### PR TITLE
Mount mkfs fix

### DIFF
--- a/recipes/data.rb
+++ b/recipes/data.rb
@@ -28,7 +28,7 @@ node.elasticsearch[:data][:devices].each do |device, params|
     action  [:mount, :enable]
 
     only_if { File.exists?(device) }
-	not_if "grep -qs #{device} /proc/mounts"
+    not_if "grep -qs #{device} /proc/mounts"
     if node.elasticsearch[:path][:data].include?(params[:mount_path])
       Chef::Log.debug "Schedule Elasticsearch service restart..."
       notifies :restart, 'service[elasticsearch]' unless node.elasticsearch[:skip_restart]


### PR DESCRIPTION
Add a not_if to the mount def to avoid trying to mount the device again and throwing errors, modified the format def to use the same not_if

Error example running chef-client after the first time the volume is created and mounted:

```
Recipe: elasticsearch::data
* bash[Format device: /dev/xvdc] action run[2013-12-19T20:09:43-08:00] INFO: Processing bash[Format device: /dev/xvdc] action run (elasticsearch::data line 4)
(skipped due to not_if)
* directory[/usr/local/var/data/elasticsearch/] action create[2013-12-19T20:09:51-08:00] INFO: Processing directory[/usr/local/var/data/elasticsearch/] action create (elasticsearch::data line 16)
(up to date)
* mount[/dev/xvdc-to-/usr/local/var/data/elasticsearch/] action mount[2013-12-19T20:09:51-08:00] INFO: Processing mount[/dev/xvdc-to-/usr/local/var/data/elasticsearch/] action mount (elasticsearch::data line 23)

================================================================================
 Error executing action `mount` on resource 'mount[/dev/xvdc-to-/usr/local/var/data/elasticsearch/]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '32'
---- Begin output of mount -t ext3 -o rw,user /dev/xvdc /usr/local/var/data/elasticsearch/ ----
STDOUT:
STDERR: mount: /dev/xvdc already mounted or /usr/local/var/data/elasticsearch/ busy
mount: according to mtab, /dev/xvdc is already mounted on /usr/local/var/data/elasticsearch
---- End output of mount -t ext3 -o rw,user /dev/xvdc /usr/local/var/data/elasticsearch/ ----
Ran mount -t ext3 -o rw,user /dev/xvdc /usr/local/var/data/elasticsearch/ returned 32
```
