### PR TITLE
Calculate download_url inside the recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,6 @@ node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_
 default.elasticsearch[:version]       = "0.90.5"
 default.elasticsearch[:host]          = "http://download.elasticsearch.org"
 default.elasticsearch[:repository]    = "elasticsearch/elasticsearch"
-default.elasticsearch[:filename]      = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
-default.elasticsearch[:download_url]  = [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')
 
 # === NAMING
 #

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,8 +72,11 @@ end
 ark_prefix_root = node.elasticsearch[:dir] || node.ark[:prefix_root]
 ark_prefix_home = node.elasticsearch[:dir] || node.ark[:prefix_home]
 
+filename = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
+download_url = [node.elasticsearch[:host], node.elasticsearch[:repository], filename].join('/')
+
 ark "elasticsearch" do
-  url   node.elasticsearch[:download_url]
+  url   download_url
   owner node.elasticsearch[:user]
   group node.elasticsearch[:user]
   version node.elasticsearch[:version]


### PR DESCRIPTION
The attributes are being pre-calculated so they don't pickup
the custom version set by the user which can lead to issues
with the wrong version being installed.

If a user needs to create a custom download_url, they can
set the host and repository attributes in their wrapper cookbook
or on the chef server. For example to create the url:

```
http://example/downloads/elasticsearch-0.90.10.tar.gz
```

you set the attributes as:

```
default.elasticsearch[:version] = '0.90.10'
default.elasticsearch[:host] = 'http://example'
default.elasticsearch[:repository] = 'downloads'
```

Fixes #178
