### PR TITLE
Depend on specific version of ark.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description      "Installs and configures elasticsearch"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.markdown'))
 version          "0.3.7"
 
-depends 'ark'
+depends 'ark', '>= 0.2.4'
 
 recommends 'build-essential'
 recommends 'xml'


### PR DESCRIPTION
This cookbook will fail with 0.2.2 or earlier because of https://github.com/opscode-cookbooks/ark/commit/0ddcd485f45840480960430218bfa6b60f341bd2
