### PR TITLE
Recipe to install from a repository

### DIFF
--- a/attributes/repoinstall.rb
+++ b/attributes/repoinstall.rb
@@ -1,0 +1,7 @@
+default.elasticsearch[:repo_gpgkey] = "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
+case node[:platform]
+when "ubuntu","debian"
+    default.elasticsearch[:repo_url] = "http://packages.elasticsearch.org/elasticsearch/0.90/debian"
+when "centos","redhat","fedora"
+    default.elasticsearch[:repo_url] = "http://packages.elasticsearch.org/elasticsearch/0.90/centos"
+end

--- a/recipes/repoinstall.rb
+++ b/recipes/repoinstall.rb
@@ -1,0 +1,58 @@
+# Download and add GPG repo key
+# Add repo entries to package tool
+
+case node[:platform]
+when "debian","ubuntu"
+    bash "install_gpg_key" do
+        user "root"
+        code "wget -O - " + node.elasticsearch[:repo_gpgkey] + "| apt-key add -"
+    end
+    template "/etc/apt/sources.list.d/elasticsearch.list" do
+        source "elasticsearch.list.erb"
+        mode 00644
+    end
+    bash "run_apt_get_update" do
+        user "root"
+        code "apt-get update"
+    end
+when "centos","redhat","fedora"
+    bash "install_gpg_key" do
+        user "root"
+        #environment {"GPG_KEY_URL" => node.elasticsearch[:repo_gpgkey]}
+        code "rpm --import " + node.elasticsearch[:repo_gpgkey]
+    end
+    template "/etc/yum.repos.d/elasticsearch.repo" do
+        source "elasticsearch.repo.erb"
+        mode 00644
+    end
+end
+
+# Install java (as elastic search package don't disclose it as dependency)
+
+case node[:platform]
+    when "debian","ubuntu"
+        package "default-jre" do
+            options "--force-yes"
+            action :install
+        end
+    when "centos","redhat","fedora"
+        package "java-1.7.0-openjdk" do
+            action :install
+        end
+end
+
+# Install elasticsearch from repo
+package "elasticsearch" do
+    case node[:platform]
+    when "debian","ubuntu"
+        options "--force-yes"
+    end
+    action :install
+end
+
+# Enable and start service
+
+service "elasticsearch" do
+    supports :status => true, :restart => true, :reload => true
+    action [ :enable, :start ]
+end

--- a/templates/default/elasticsearch.list.erb
+++ b/templates/default/elasticsearch.list.erb
@@ -1,0 +1,1 @@
+deb <%= node.elasticsearch[:repo_url] %> stable main

--- a/templates/default/elasticsearch.repo.erb
+++ b/templates/default/elasticsearch.repo.erb
@@ -1,0 +1,6 @@
+[elasticsearch]
+name=Elasticsearch repository
+baseurl=<%= node.elasticsearch[:repo_url] %>
+gpgcheck=1
+gpgkey=<%= node.elasticsearch[:repo_gpgkey] %>
+enabled=1


### PR DESCRIPTION
I've created a recipe, named repoinstall, to be used for package installation from a repository. It supports both apt and yum based repos.

Tested with Ubuntu 12.04 and CentOS 6.

The default repo attributes point to the one available on Elasticsearch website - http://www.elasticsearch.org/blog/apt-and-yum-repositories/.

To use this recipe just call elasticsearch::repoinstall on your runlist.