### PR TITLE
Allow any custom configuration

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,8 @@
 
 Erubis::Context.send(:include, Extensions::Templates)
 
+require 'yaml'
+
 elasticsearch = "elasticsearch-#{node.elasticsearch[:version]}"
 
 include_recipe "elasticsearch::curl"
@@ -129,6 +131,9 @@ template "elasticsearch.yml" do
   path   "#{node.elasticsearch[:path][:conf]}/elasticsearch.yml"
   source "elasticsearch.yml.erb"
   owner node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
+  variables(
+    'custom_config' => node.elasticsearch[:custom_config].to_yaml.gsub(/^---/,''),
+  )
 
   notifies :restart, 'service[elasticsearch]' unless node.elasticsearch[:skip_restart]
 end

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -140,6 +140,6 @@ jmx.domain: elasticsearch
 
 ################################## Custom #####################################
 
-<% node.elasticsearch[:custom_config].sort.each do |key, value| %>
-<%= key %>: <%= value %>
+<% @custom_config.lines.each do |line| %>
+<%= line.gsub(/!ruby.*$/,'').gsub(/\n$/,'') %>
 <% end %>


### PR DESCRIPTION
When defining custom analyzer you need to specify full yaml instead of pure key values.
This patch is not perfect but does the job.
