### PR TITLE
Remove default.elasticsearch[:filename] and default.elasticsearch[:downl...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,6 @@ node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_
 default.elasticsearch[:version]       = "0.90.12"
 default.elasticsearch[:host]          = "http://download.elasticsearch.org"
 default.elasticsearch[:repository]    = "elasticsearch/elasticsearch"
-default.elasticsearch[:filename]      = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
-default.elasticsearch[:download_url]  = [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')
 
 # === NAMING
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email "karmi@karmi.cz"
 license          "Apache"
 description      "Installs and configures elasticsearch"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.markdown'))
-version          "0.3.7"
+version          "0.3.8"
 
 depends 'ark', '>= 0.2.4'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -73,7 +73,7 @@ ark_prefix_root = node.elasticsearch[:dir] || node.ark[:prefix_root]
 ark_prefix_home = node.elasticsearch[:dir] || node.ark[:prefix_home]
 
 ark "elasticsearch" do
-  url   node.elasticsearch[:download_url]
+  url   [node.elasticsearch[:host], node.elasticsearch[:repository], "elasticsearch-#{node.elasticsearch[:version]}.tar.gz" ].join('/')
   owner node.elasticsearch[:user]
   group node.elasticsearch[:user]
   version node.elasticsearch[:version]


### PR DESCRIPTION
...oad_url] from the attribute file.  This allows setting the default.elasticsearch[:version] attribute from recipes or wrapper cookbooks to work as expected
