### PR TITLE
bumped version of fog from 1.12.1 to 1.21.0

### DIFF
--- a/recipes/ebs.rb
+++ b/recipes/ebs.rb
@@ -12,7 +12,7 @@ end
 # Install the Fog gem for Chef run
 #
 chef_gem("fog") do
-  version '1.12.1'
+  version '1.21.0'
   action :install
 end
 


### PR DESCRIPTION
I had some errors when running the cookbook as, it turned out, I didn't set the AWS region correctly.
Fog (version 1.12.1) returns a null instance for aws when the region is incorrect with no verbose debug information when this occurs:

```
NoMethodError: ruby_block[Create EBS volume on /dev/sda2 (size: 25GB)] (elasticsearch::ebs line 16) had an error: NoMethodError: undefined method `volumes' for nil:NilClass
/var/chef-solo/cookbooks/elasticsearch/libraries/create_ebs.rb:41:in `block (2 levels) in create_ebs'
```

Instead with the latest version it was able to show the issue more explicitly:

```
ArgumentError
-------------
Unknown region: "us-west-2b"
```

Note also I entered us-west-2b whereas it expects only us-west-2 (just for others reading this).
