### PR TITLE
add option skip_start

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,6 +82,7 @@ default.elasticsearch[:env_options] = ""
 # === OTHER SETTINGS
 #
 default.elasticsearch[:skip_restart] = false
+default.elasticsearch[:skip_start] = false
 
 # === PORT
 #

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,7 +82,7 @@ ark "elasticsearch" do
   prefix_root   ark_prefix_root
   prefix_home   ark_prefix_home
 
-  notifies :start,   'service[elasticsearch]'
+  notifies :start,   'service[elasticsearch]' unless node.elasticsearch[:skip_start]
   notifies :restart, 'service[elasticsearch]' unless node.elasticsearch[:skip_restart]
 
   not_if do


### PR DESCRIPTION
Sometimes we may not want elasticsearch to start right after an
installation.
