### PR TITLE
Fix removal of stale pid file in elasticsearch init script.

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -75,7 +75,7 @@ stop() {
       if [ ! $CHECK_PID_RUNNING ]; then
         echo -e "\033[1mPID file found, but no matching process running?\033[0m"
         echo    "Removing PID file..."
-        su <%= node[:elasticsearch][:user] %> -m -c "rm $PIDFILE"
+        rm $PIDFILE
         exit 0
       fi
 


### PR DESCRIPTION
See https://github.com/elasticsearch/cookbook-elasticsearch/issues/224

Test case:

```
sudo service elasticsearch start
sudo service elasticsearch stop
sudo service elasticsearch restart
```
