### PR TITLE
Updated Logging template

### DIFF
--- a/attributes/logging.rb
+++ b/attributes/logging.rb
@@ -1,3 +1,4 @@
+default.elasticsearch[:es][:logger]['level'] = 'ERROR'
 default.elasticsearch[:logging]['action'] = 'DEBUG'
 default.elasticsearch[:logging]['com.amazonaws'] = 'WARN'
 default.elasticsearch[:logging]['index.search.slowlog'] = 'TRACE, index_search_slow_log_file'

--- a/templates/default/logging.yml.erb
+++ b/templates/default/logging.yml.erb
@@ -25,8 +25,8 @@
 #     // ...
 #
 
-es.logger.level: INFO
-rootLogger: INFO, console, file
+<%= print_value 'es.logger.level' -%>
+rootLogger: ERROR, console, file
 
 # ----- Configuration set by Chef ---------------------------------------------
 <% node.elasticsearch[:logging].sort.each do |key, value| %>
@@ -48,6 +48,7 @@ appender:
   file:
     type: dailyRollingFile
     file: ${path.logs}/${cluster.name}.log
+    maxBackupIndex: 1
     datePattern: "'.'yyyy-MM-dd"
     layout:
       type: pattern
@@ -56,6 +57,7 @@ appender:
   index_search_slow_log_file:
     type: dailyRollingFile
     file: ${path.logs}/${cluster.name}_index_search_slowlog.log
+    maxBackupIndex: 1
     datePattern: "'.'yyyy-MM-dd"
     layout:
       type: pattern
@@ -63,6 +65,7 @@ appender:
 
   index_indexing_slow_log_file:
     type: dailyRollingFile
+    maxBackupIndex: 1
     file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
     datePattern: "'.'yyyy-MM-dd"
     layout:


### PR DESCRIPTION
On a production system where there are a lot of nodes, logs produced by ES quickly fill local disk. Rather than creating a cronjob or clean-up script. It should be possible for a user to determine weather logging is turned on and also to set ES to only retain a certain number of days of logs via log4j.