### PR TITLE
Degrade gracefully if node.memory is not defined

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,11 +73,7 @@ CONFIG
 # By default, the `mlockall` is set to true: on weak machines and Vagrant boxes,
 # you may want to disable it.
 #
-if node[:memory]
-  default.elasticsearch[:bootstrap][:mlockall] = ( node.memory.total.to_i >= 1048576 ? true : false )
-else
-  default.elasticsearch[:bootstrap][:mlockall] = false
-end
+default.elasticsearch[:bootstrap][:mlockall] = ( node[:memory] && node.memory.total.to_i < 1048576 ? false : true )
 default.elasticsearch[:limits][:memlock] = 'unlimited'
 default.elasticsearch[:limits][:nofile]  = '64000'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,7 +51,11 @@ default.elasticsearch[:templates][:logging_yml]       = "logging.yml.erb"
 # Maximum amount of memory to use is automatically computed as one half of total available memory on the machine.
 # You may choose to set it in your node/role configuration instead.
 #
-allocated_memory = "#{(node.memory.total.to_i * 0.6 ).floor / 1024}m"
+if node[:memory]
+  allocated_memory = "#{(node.memory.total.to_i * 0.6 ).floor / 1024}m"
+else
+  allocated_memory = 1024
+end
 default.elasticsearch[:allocated_memory] = allocated_memory
 
 # === GARBAGE COLLECTION SETTINGS
@@ -69,7 +73,11 @@ CONFIG
 # By default, the `mlockall` is set to true: on weak machines and Vagrant boxes,
 # you may want to disable it.
 #
-default.elasticsearch[:bootstrap][:mlockall] = ( node.memory.total.to_i >= 1048576 ? true : false )
+if node[:memory]
+  default.elasticsearch[:bootstrap][:mlockall] = ( node.memory.total.to_i >= 1048576 ? true : false )
+else
+  default.elasticsearch[:bootstrap][:mlockall] = false
+end
 default.elasticsearch[:limits][:memlock] = 'unlimited'
 default.elasticsearch[:limits][:nofile]  = '64000'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,10 +53,8 @@ default.elasticsearch[:templates][:logging_yml]       = "logging.yml.erb"
 #
 if node[:memory]
   allocated_memory = "#{(node.memory.total.to_i * 0.6 ).floor / 1024}m"
-else
-  allocated_memory = 1024
+  default.elasticsearch[:allocated_memory] = allocated_memory
 end
-default.elasticsearch[:allocated_memory] = allocated_memory
 
 # === GARBAGE COLLECTION SETTINGS
 #

--- a/templates/default/elasticsearch-env.sh.erb
+++ b/templates/default/elasticsearch-env.sh.erb
@@ -6,14 +6,16 @@
 <%= "JAVA_HOME='#{node.elasticsearch[:java_home]}'\n" if node.elasticsearch[:java_home] -%>
 ES_HOME='<%= "#{node.elasticsearch[:dir]}/elasticsearch" %>'
 ES_CLASSPATH=$ES_CLASSPATH:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*
-ES_HEAP_SIZE=<%= node.elasticsearch[:allocated_memory] || 1024 %>
+<%= "ES_HEAP_SIZE=#{node.elasticsearch[:allocated_memory]}\n" if node.elasticsearch[:allocated_memory] -%>
 
 ES_JAVA_OPTS="
   -server
   -Djava.net.preferIPv4Stack=true
   -Des.config=<%= node.elasticsearch[:path][:conf] %>/elasticsearch.yml
-  -Xms<%= node.elasticsearch[:allocated_memory] || 1024 %>
-  -Xmx<%= node.elasticsearch[:allocated_memory] || 1024 %>
+<% if node.elasticsearch[:allocated_memory] -%>
+  -Xms<%= node.elasticsearch[:allocated_memory] %>
+  -Xmx<%= node.elasticsearch[:allocated_memory] %>
+<% end -%>
   -Xss<%= node.elasticsearch[:thread_stack_size] %>
   <%= node.elasticsearch[:gc_settings] %>
 <% if node.elasticsearch[:jmx] %>

--- a/templates/default/elasticsearch-env.sh.erb
+++ b/templates/default/elasticsearch-env.sh.erb
@@ -6,14 +6,14 @@
 <%= "JAVA_HOME='#{node.elasticsearch[:java_home]}'\n" if node.elasticsearch[:java_home] -%>
 ES_HOME='<%= "#{node.elasticsearch[:dir]}/elasticsearch" %>'
 ES_CLASSPATH=$ES_CLASSPATH:$ES_HOME/lib/*:$ES_HOME/lib/sigar/*
-ES_HEAP_SIZE=<%= node.elasticsearch[:allocated_memory] %>
+ES_HEAP_SIZE=<%= node.elasticsearch[:allocated_memory] || 1024 %>
 
 ES_JAVA_OPTS="
   -server
   -Djava.net.preferIPv4Stack=true
   -Des.config=<%= node.elasticsearch[:path][:conf] %>/elasticsearch.yml
-  -Xms<%= node.elasticsearch[:allocated_memory] %>
-  -Xmx<%= node.elasticsearch[:allocated_memory] %>
+  -Xms<%= node.elasticsearch[:allocated_memory] || 1024 %>
+  -Xmx<%= node.elasticsearch[:allocated_memory] || 1024 %>
   -Xss<%= node.elasticsearch[:thread_stack_size] %>
   <%= node.elasticsearch[:gc_settings] %>
 <% if node.elasticsearch[:jmx] %>


### PR DESCRIPTION
On Windows, Ohai does not set node.memory.  If the elasticsearch cookbook is listed as a dependency on a Windows box (even if it is not used on Windows), this will cause chef to fail.

This hardcodes memory limits if node.memory is not available.

We depend on the elasticsearch cookbook in one of our base cookbooks that applies to all systems (including Windows).  We do not actually include recipes from elasticsearch on Windows and have no intention of using the elasticsearch cookbook on Windows.  But merely including it in metadata.rb is enough to cause Windows chef runs to fail.