### PR TITLE
adding AWS availability zone detection

### DIFF
--- a/attributes/awszone.rb
+++ b/attributes/awszone.rb
@@ -1,0 +1,9 @@
+require 'open-uri'
+
+def awszone
+    begin
+        normal[:elasticsearch][:node][:awszone] = open('http://169.254.169.254/latest/meta-data/placement/availability-zone'){|f| f.gets}
+    rescue OpenURI::HTTPError => error
+        response = error.io
+    end
+end

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -24,6 +24,7 @@
 <%= print_value 'node.name' -%>
 <%= print_value 'node.master' -%>
 <%= print_value 'node.data' -%>
+<%= print_value 'node.awszone' -%>
 <%= print_value 'node.max_local_storage_nodes' -%>
 
 #################################### Index ####################################


### PR DESCRIPTION
This simple edit will set the config value node.awszone if the HTTP request is successful. If unsuccessful the error is captured and the config value is omitted from elasticsearch.yml
