### PR TITLE
Configurable monit health check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -142,3 +142,8 @@ default.elasticsearch[:logging] = {}
 #     'threadpool.index.size' => '2'
 #     // ...
 #
+
+# When you have only one node, health will always be yellow.
+# And if you are use `recipe[elasticsearch::monit]`, will be better to turn off the heath check.
+#
+default.elasticsearch[:monit][:health] = true

--- a/templates/default/elasticsearch.monitrc.conf.erb
+++ b/templates/default/elasticsearch.monitrc.conf.erb
@@ -15,6 +15,7 @@ check host elasticsearch_connection with address 0.0.0.0
   if failed url http://0.0.0.0:<%= node.elasticsearch[:http][:port] %>/ with timeout 15 seconds then alert
   group elasticsearch
 
+  <% if node.elasticsearch[:monit][:health] %>
 check host elasticsearch_cluster_health with address 0.0.0.0
   if failed url http://0.0.0.0:<%= node.elasticsearch[:http][:port] %>/_cluster/health
      and content == 'green'
@@ -29,4 +30,5 @@ check host elasticsearch_cluster_health with address 0.0.0.0
                  <% end %>
      }
   group elasticsearch
+  <% end %>
 <% end %>


### PR DESCRIPTION
When you have only one node, health will always be yellow.
And if you are use `recipe[elasticsearch::monit]`, will be better to turn off the heath check.
