### PR TITLE
Computation of `dowload_url` moved to recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,8 @@ node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_
 default.elasticsearch[:version]       = "0.90.12"
 default.elasticsearch[:host]          = "http://download.elasticsearch.org"
 default.elasticsearch[:repository]    = "elasticsearch/elasticsearch"
-default.elasticsearch[:filename]      = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
-default.elasticsearch[:download_url]  = [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')
+default.elasticsearch[:filename]      = nil
+default.elasticsearch[:download_url]  = nil
 
 # === NAMING
 #

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,8 +79,12 @@ end
 ark_prefix_root = node.elasticsearch[:dir] || node.ark[:prefix_root]
 ark_prefix_home = node.elasticsearch[:dir] || node.ark[:prefix_home]
 
+filename = node.elasticsearch[:filename] || "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
+download_url = node.elasticsearch[:download_url] || [node.elasticsearch[:host],
+                node.elasticsearch[:repository], filename].join('/')
+
 ark "elasticsearch" do
-  url   node.elasticsearch[:download_url]
+  url   download_url
   owner node.elasticsearch[:user]
   group node.elasticsearch[:user]
   version node.elasticsearch[:version]


### PR DESCRIPTION
Computation of the download filename and download URL in the defaults.rb attributes file was causing potentially confusing behavior upon node convergence. If the user overrode the node.elasticsearch[:version] property, the download directory and symlinks would be created with the correctly overridden version number. However, the download URL would be computed with the default version number, and thus the incorrect, default version of elasticsearch would be installed.

Since there's no need to compute the download filename and URL until node convergence, this pull request moves that computation to the default.rb recipe. However, the node.elasticsearch[:filename] and node.elasticsearch[:download_url] attributes, if present, are respected and given preference upon node convergence, so that users still have the capability to override these attributes and thus configure downloads from a custom repository.
