### PR TITLE
Moved download_url compilation to the default recipe to allow overriding

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,14 +13,11 @@ include_attribute 'elasticsearch::customize'
 node.normal[:elasticsearch]    = DeepMerge.merge(node.default[:elasticsearch].to_hash, node.normal[:elasticsearch].to_hash)
 node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_hash, settings.to_hash)
 
-
 # === VERSION AND LOCATION
 #
 default.elasticsearch[:version]       = "0.90.12"
 default.elasticsearch[:host]          = "http://download.elasticsearch.org"
 default.elasticsearch[:repository]    = "elasticsearch/elasticsearch"
-default.elasticsearch[:filename]      = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
-default.elasticsearch[:download_url]  = [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')
 
 # === NAMING
 #
@@ -40,7 +37,6 @@ default.elasticsearch[:path][:data] = "/usr/local/var/data/elasticsearch"
 default.elasticsearch[:path][:logs] = "/usr/local/var/log/elasticsearch"
 
 default.elasticsearch[:pid_path]  = "/usr/local/var/run"
-default.elasticsearch[:pid_file]  = "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node][:name].to_s.gsub(/\W/, '_')}.pid"
 
 default.elasticsearch[:templates][:elasticsearch_env] = "elasticsearch-env.sh.erb"
 default.elasticsearch[:templates][:elasticsearch_yml] = "elasticsearch.yml.erb"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,13 @@ Erubis::Context.send(:include, Extensions::Templates)
 
 elasticsearch = "elasticsearch-#{node.elasticsearch[:version]}"
 
+# This needs to happen in the recipe; included cookbooks' attributes are evaluated before the caller's.
+# Compiling attributes in attribute files will prevent modification by wrapper cookbooks
+#
+node.default.elasticsearch[:filename]     = "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
+node.default.elasticsearch[:download_url] = [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')
+node.default.elasticsearch[:pid_file]     = "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node][:name].to_s.gsub(/\W/, '_')}.pid"
+
 include_recipe "elasticsearch::curl"
 include_recipe "ark"
 
@@ -80,12 +87,12 @@ ark_prefix_root = node.elasticsearch[:dir] || node.ark[:prefix_root]
 ark_prefix_home = node.elasticsearch[:dir] || node.ark[:prefix_home]
 
 ark "elasticsearch" do
-  url   node.elasticsearch[:download_url]
-  owner node.elasticsearch[:user]
-  group node.elasticsearch[:user]
-  version node.elasticsearch[:version]
-  has_binaries ['bin/elasticsearch', 'bin/plugin']
-  checksum node.elasticsearch[:checksum]
+  url           node.elasticsearch[:download_url]
+  owner         node.elasticsearch[:user]
+  group         node.elasticsearch[:user]
+  version       node.elasticsearch[:version]
+  has_binaries  ['bin/elasticsearch', 'bin/plugin']
+  checksum      node.elasticsearch[:checksum]
   prefix_root   ark_prefix_root
   prefix_home   ark_prefix_home
 


### PR DESCRIPTION
Overriding certain attributes from wrapper cookbook attributes didn't work. I know this cookbook implements a customization strategy, but it was also ineffective in this case, let me explain why.

As you can see in the patch below, compilation of elasticsearch.filename and elasticsearch.download_url happens during interpretation of the attributes of this cookbook, which _always_ happens before interpretation of the caller's attributes. This is not mentioned in the official Chef docs, but this article explains it quite clearly: [Chef Blog](https://www.getchef.com/blog/2013/12/03/doing-wrapper-cookbooks-right/)

Specifying default.version, normal.version or override.version in a wrapper cookbook always led to the following values (with 1.3.4 for example):
- :version - 1.3.4
- :download_url - https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.12.tar.gz
- :filename - elasticsearch-0.90.12.tar.gz

This would lead to Ark downloading 0.90.12, saving it as elasticsearch-1.3.4.tar.gz and installing it under /usr/local/elasticsearch-1.3.4. Time was wasted finding out why ES wouldn't upgrade. :) This patch fixes this behaviour.
