### PR TITLE
Use default node attributes for download_url, filename and pid_file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,7 @@ default.elasticsearch[:path][:data] = "/usr/local/var/data/elasticsearch"
 default.elasticsearch[:path][:logs] = "/usr/local/var/log/elasticsearch"
 
 default.elasticsearch[:pid_path]  = "/usr/local/var/run"
-default.elasticsearch[:pid_file]  = "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node][:name].to_s.gsub(/\W/, '_')}.pid"
+default.elasticsearch[:pid_file]  = nil
 
 default.elasticsearch[:templates][:elasticsearch_env] = "elasticsearch-env.sh.erb"
 default.elasticsearch[:templates][:elasticsearch_yml] = "elasticsearch.yml.erb"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,10 @@ Erubis::Context.send(:include, Extensions::Templates)
 
 elasticsearch = "elasticsearch-#{node.elasticsearch[:version]}"
 
+node.default.elasticsearch[:filename]      ||= "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
+node.default.elasticsearch[:download_url]  ||= [node.elasticsearch[:host], node.elasticsearch[:repository], node.elasticsearch[:filename]].join('/')
+node.default.elasticsearch[:pid_file]      ||= "#{node.elasticsearch[:pid_path]}/#{node.elasticsearch[:node][:name].to_s.gsub(/\W/, '_')}.pid"
+
 include_recipe "elasticsearch::curl"
 include_recipe "ark"
 
@@ -33,7 +37,6 @@ bash "remove the elasticsearch user home" do
   not_if  { ::File.symlink?("#{node.elasticsearch[:dir]}/elasticsearch") }
   only_if { ::File.directory?("#{node.elasticsearch[:dir]}/elasticsearch") }
 end
-
 
 # Create ES directories
 #
@@ -79,17 +82,13 @@ end
 ark_prefix_root = node.elasticsearch[:dir] || node.ark[:prefix_root]
 ark_prefix_home = node.elasticsearch[:dir] || node.ark[:prefix_home]
 
-filename = node.elasticsearch[:filename] || "elasticsearch-#{node.elasticsearch[:version]}.tar.gz"
-download_url = node.elasticsearch[:download_url] || [node.elasticsearch[:host],
-                node.elasticsearch[:repository], filename].join('/')
-
 ark "elasticsearch" do
-  url   download_url
-  owner node.elasticsearch[:user]
-  group node.elasticsearch[:user]
-  version node.elasticsearch[:version]
-  has_binaries ['bin/elasticsearch', 'bin/plugin']
-  checksum node.elasticsearch[:checksum]
+  url           node.elasticsearch[:download_url]
+  owner         node.elasticsearch[:user]
+  group         node.elasticsearch[:user]
+  version       node.elasticsearch[:version]
+  has_binaries  ['bin/elasticsearch', 'bin/plugin']
+  checksum      node.elasticsearch[:checksum]
   prefix_root   ark_prefix_root
   prefix_home   ark_prefix_home
 


### PR DESCRIPTION
As discussed in #245, this is @jakekdodd's solution. Will extensively test this in the coming days.

Systems that upgraded from an earlier version to the #242 patch should still have the ```download_url```and ```filename``` node parameters cached in the Chef Server.
New installations with that cookbook will have those attributes 'nil' or missing entirely. This patch should restore functionality.