### PR TITLE
Modifying Berksfile to be compatible with the latest version of berks

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
+source 'https://supermarket.getchef.com'
 metadata
 
 cookbook 'apt', git: 'git://github.com/opscode-cookbooks/apt.git'


### PR DESCRIPTION
I'm a novice at chef, but it seems like the latest version of Berks packaged with chef-dk requires a `source` statement at the top of the file.