### PR TITLE
Allow cookbook wrappers to specify a cookbook where to look for templates

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,9 @@ default.elasticsearch[:templates][:elasticsearch_env] = "elasticsearch-env.sh.er
 default.elasticsearch[:templates][:elasticsearch_yml] = "elasticsearch.yml.erb"
 default.elasticsearch[:templates][:logging_yml]       = "logging.yml.erb"
 
+default.elasticsearch[:templates][:elasticsearch_yml_cookbook] = "elasticsearch"
+default.elasticsearch[:templates][:logging_yml_cookbook]       = "elasticsearch"
+
 # === MEMORY
 #
 # Maximum amount of memory to use is automatically computed as one half of total available memory on the machine.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -141,6 +141,7 @@ end
 template "elasticsearch.yml" do
   path   "#{node.elasticsearch[:path][:conf]}/elasticsearch.yml"
   source node.elasticsearch[:templates][:elasticsearch_yml]
+  cookbook node.elasticsearch[:templates][:elasticsearch_yml_cookbook]
   owner  node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
 
   notifies :restart, 'service[elasticsearch]' unless node.elasticsearch[:skip_restart]
@@ -151,6 +152,7 @@ end
 template "logging.yml" do
   path   "#{node.elasticsearch[:path][:conf]}/logging.yml"
   source node.elasticsearch[:templates][:logging_yml]
+  cookbook node.elasticsearch[:templates][:logging_yml_cookbook]
   owner  node.elasticsearch[:user] and group node.elasticsearch[:user] and mode 0755
 
   notifies :restart, 'service[elasticsearch]' unless node.elasticsearch[:skip_restart]


### PR DESCRIPTION
Hi,

It would be nice to have an easy option to override template's cookbook using cookbook wrapper.
Currently we have do it with:
```
include_recipe "elasticsearch"
resources('template[elasticsearch.yml]').cookbook 'wrapper-cookbook'
```