### PR TITLE
"allocated_memory" now uses 50% of memory by default.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,7 +51,7 @@ default.elasticsearch[:templates][:logging_yml]       = "logging.yml.erb"
 # Maximum amount of memory to use is automatically computed as one half of total available memory on the machine.
 # You may choose to set it in your node/role configuration instead.
 #
-allocated_memory = "#{(node.memory.total.to_i * 0.6 ).floor / 1024}m"
+allocated_memory = "#{(node.memory.total.to_i * 0.5 ).floor / 1024}m"
 default.elasticsearch[:allocated_memory] = allocated_memory
 
 # === GARBAGE COLLECTION SETTINGS


### PR DESCRIPTION
This is the official recommendation by elasticsearch (see [elasticsearch guide](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_limiting_memory_usage.html)) and also specified in the above comment (quote "as one half of total available memory").

Previously 60% of memory where used.