### PR TITLE
Only invoke ulimit when starting service

### DIFF
--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -23,11 +23,6 @@
 #
 if [ -f /etc/sysconfig/network ]; then source /etc/sysconfig/network; fi
 
-# Set limits for environments ignoring `/etc/security/limits.d`
-#
-ulimit -n <%= node[:elasticsearch][:limits][:nofile] %>
-ulimit -l <%= node[:elasticsearch][:limits][:memlock] %>
-
 # Exit if networking is not up
 #
 [ "$NETWORKING" = "no" ] && exit
@@ -37,6 +32,11 @@ ES_INCLUDE='<%= node.elasticsearch[:path][:conf] %>/elasticsearch-env.sh'
 CHECK_PID_RUNNING=$(ps ax | grep 'java' | grep -e "es.pidfile=$PIDFILE" | sed 's/^\s*\([0-9]*\)\s.*/\1/')
 
 start() {
+    # Set limits for environments ignoring `/etc/security/limits.d`
+    #
+    ulimit -n <%= node[:elasticsearch][:limits][:nofile] %>
+    ulimit -l <%= node[:elasticsearch][:limits][:memlock] %>
+
     if [ -f $PIDFILE ]; then
       # PIDFILE EXISTS -- ES RUNNING?
       echo -e "PID file found in $PIDFILE"


### PR DESCRIPTION
ulimit can only be invoked by the root user, so when this init script is called by a non-root user (eg. to check the service status) then it writes a message to stderr. Maybe ulimit should be moved into the start() block? 