### PR TITLE
Encrypted EBS supported

### DIFF
--- a/libraries/create_ebs.rb
+++ b/libraries/create_ebs.rb
@@ -42,6 +42,7 @@ module Extensions
           options = { :device                => ebs_device,
                       :size                  => params[:ebs][:size],
                       :delete_on_termination => params[:ebs][:delete_on_termination],
+                      :encrypted             => params[:ebs][:encrypted],
                       :availability_zone     => server.availability_zone,
                       :server                => server }
 

--- a/recipes/ebs.rb
+++ b/recipes/ebs.rb
@@ -12,7 +12,7 @@ end
 # Install the Fog gem for Chef run
 #
 chef_gem("fog") do
-  version '1.21.0'
+  version '1.25.0'
   action :install
 end
 


### PR DESCRIPTION
Encrypted EBS can be created using `create_ebs`. This is same as #236  but it didn't worked for me.  FOG update was required to be able to encrypt EBS.