### PR TITLE
Add the repo to RPM and DEB based installs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,8 @@ node.normal[:elasticsearch]    = DeepMerge.merge(node.normal[:elasticsearch].to_
 
 # === VERSION AND LOCATION
 #
-default.elasticsearch[:version]       = "0.90.12"
+default.elasticsearch[:major_version] = "1.4"
+default.elasticsearch[:version]       = "1.4.2"
 default.elasticsearch[:host]          = "http://download.elasticsearch.org"
 default.elasticsearch[:repository]    = "elasticsearch/elasticsearch"
 default.elasticsearch[:filename]      = nil

--- a/recipes/deb.rb
+++ b/recipes/deb.rb
@@ -1,16 +1,17 @@
 # See <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_linux.html>
 
-filename = node.elasticsearch[:deb_url].split('/').last
-
-remote_file "#{Chef::Config[:file_cache_path]}/#{filename}" do
-  source   node.elasticsearch[:deb_url]
-  checksum node.elasticsearch[:deb_sha]
-  mode 00644
+apt_repository 'elasticsearch' do
+  uri "http://packages.elasticsearch.org/elasticsearch/#{node['elasticsearch']['major_version']}/debian"
+  distribution 'stable'
+  components ['main']
+  key 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch'
+  only_if { node['platform'] == 'debian' || node['platform'] == 'ubuntu' }
 end
 
-dpkg_package "#{Chef::Config[:file_cache_path]}/#{filename}" do
+package 'elasticsearch' do
   action :install
 end
+
 
 ruby_block "Set heap size in /etc/default/elasticsearch" do
   block do

--- a/recipes/rpm.rb
+++ b/recipes/rpm.rb
@@ -1,13 +1,12 @@
 # See <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_linux.html>
 
-filename = node.elasticsearch[:rpm_url].split('/').last
-
-remote_file "#{Chef::Config[:file_cache_path]}/#{filename}" do
-  source   node.elasticsearch[:rpm_url]
-  checksum node.elasticsearch[:rpm_sha]
-  mode 00644
+yum_repository 'logstash' do
+  description "logstash repository for #{node['elasticsearch']['major_version']}.x packages"
+  baseurl "http://packages.elasticsearch.org/elasticsearch/#{node['elasticsearch']['major_version']}/centos"
+  gpgkey 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch'
+  only_if { node['platform'] == 'centos' }
 end
 
-rpm_package "#{Chef::Config[:file_cache_path]}/#{filename}" do
+package 'elasticsearch' do
   action :install
 end


### PR DESCRIPTION
Before, installing the deb or rpm was a one off operation.
Adding the package manager version will make it easier to keep elasticsearch up to date.

Also, version bump to 1.4.2.