### PR TITLE
allow options passing to package provider

### DIFF
--- a/libraries/provider_install_package.rb
+++ b/libraries/provider_install_package.rb
@@ -14,9 +14,10 @@ class Chef
           package_url = get_package_url(new_resource, node)
           filename = package_url.split('/').last
           checksum = get_package_checksum(new_resource, node)
+          package_options = new_resource.package_options
 
           download_package(package_url, "#{Chef::Config[:file_cache_path]}/#{filename}", checksum)
-          install_package("#{Chef::Config[:file_cache_path]}/#{filename}")
+          install_package("#{Chef::Config[:file_cache_path]}/#{filename}", package_options)
         end
       end
     end
@@ -49,8 +50,9 @@ class Chef
       end
     end
 
-    def install_package(path)
+    def install_package(path, package_options)
       package path do
+        options package_options
         action :install
       end
     end

--- a/libraries/resource_install.rb
+++ b/libraries/resource_install.rb
@@ -15,6 +15,7 @@ class Chef
     # attributes used by the package-flavor provider
     attribute(:package_url, kind_of: String, default: nil)
     attribute(:package_checksum, kind_of: String, default: nil)
+    attribute(:package_options, kind_of: String, default: nil)
 
     # attributes used by the source-flavor provider
     attribute(:source_url, kind_of: String, default: lazy {  "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{version}.tar.gz" } )


### PR DESCRIPTION
Hi @karmi 

If you install `1.5.0` and try to update the provider version/url to point to `1.6.0` for example, **assuming that you match the conf path with the one from the elastic package (`/etc/elasticsearch`)**, then you need to be able to pass something like this:

    "--force-yes -o Dpkg::Options::='--force-confold'"

Thanks for looking at it, without it there's no way to be able to update nodes in place currently.