### PR TITLE
Rename provider source to tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ end
 Downloads the elasticsearch software, and unpacks it on the system. There are
 currently two ways to install -- `package`, which downloads the appropriate
 package from elasticsearch.org and uses the package manager to install it, and
-`source` which downloads a tarball from elasticsearch.org and unpacks it in
+`tarball` which downloads a tarball from elasticsearch.org and unpacks it in
 /usr/local on the system. The resource name is not used for anything in
 particular. This resource also comes with a `:remove` action which will remove
 the package or directory elasticsearch was unpacked into.
@@ -49,14 +49,14 @@ Examples:
 
 ```
 elasticsearch_install 'my_es_installation' do
-  type :source # type of install
+  type :tarball # type of install
   dir '/usr/local' # where to install
 
   owner 'elasticsearch' # user and group to install under
   group 'elasticsearch'
 
-  source_url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.0.tar.gz"
-  source_checksum "acf572c606552bc446cceef3f8e93814a363ba0d215b323a2864682b3abfbe45"
+  tarball_url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.0.tar.gz"
+  tarball_checksum "acf572c606552bc446cceef3f8e93814a363ba0d215b323a2864682b3abfbe45"
 
   action :install # could be :remove as well
 end
@@ -64,7 +64,7 @@ end
 
 ```
 elasticsearch_install 'my_es_installation' do
-  type :source # type of install
+  type :tarball # type of install
   version '1.5.0'
   action :install # could be :remove as well
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,11 +24,11 @@ module ElasticsearchCookbook
       end
     end
 
-    def get_source_home_dir(new_resource, node)
+    def get_tarball_home_dir(new_resource, node)
       new_resource.dir || node.ark[:prefix_home]
     end
 
-    def get_source_root_dir(new_resource, node)
+    def get_tarball_root_dir(new_resource, node)
       new_resource.dir || node.ark[:prefix_root]
     end
 

--- a/libraries/provider_install_source.rb
+++ b/libraries/provider_install_source.rb
@@ -15,14 +15,14 @@ class Chef
           include_recipe 'curl'
 
           ark "elasticsearch" do
-            url   new_resource.source_url
+            url   new_resource.tarball_url
             owner new_resource.owner
             group new_resource.group
             version new_resource.version
             has_binaries ['bin/elasticsearch', 'bin/plugin']
-            checksum new_resource.source_checksum
-            prefix_root   get_source_root_dir(new_resource, node)
-            prefix_home   get_source_home_dir(new_resource, node)
+            checksum new_resource.tarball_checksum
+            prefix_root   get_tarball_root_dir(new_resource, node)
+            prefix_home   get_tarball_home_dir(new_resource, node)
 
             not_if do
               link   = "#{new_resource.dir}/elasticsearch"
@@ -61,7 +61,7 @@ class Chef
     class << self
       # supports the given resource and action (late binding)
       def supports?(resource, action)
-        resource.type == :source
+        resource.type == :tarball
       end
     end
 

--- a/libraries/provider_plugin.rb
+++ b/libraries/provider_plugin.rb
@@ -19,7 +19,7 @@ class Chef
 
           install_resource = found_installs.first
           es_version = install_resource.instance_variable_get(:@version)
-          es_dir = get_source_root_dir(install_resource, node)
+          es_dir = get_tarball_root_dir(install_resource, node)
 
           new_resource.plugin_dir "#{es_dir}/elasticsearch-#{es_version}/plugins"
         end

--- a/libraries/resource_install.rb
+++ b/libraries/resource_install.rb
@@ -9,7 +9,7 @@ class Chef
     actions(:install, :remove)
     default_action :install
 
-    attribute(:type, kind_of: Symbol, :equal_to => [:source, :package], default: :source)
+    attribute(:type, kind_of: Symbol, :equal_to => [:tarball, :package], default: :tarball)
     attribute(:version, kind_of: String, default: '1.5.0')
 
     # attributes used by the package-flavor provider
@@ -17,9 +17,9 @@ class Chef
     attribute(:package_checksum, kind_of: String, default: nil)
     attribute(:package_options, kind_of: String, default: nil)
 
-    # attributes used by the source-flavor provider
-    attribute(:source_url, kind_of: String, default: lazy {  "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{version}.tar.gz" } )
-    attribute(:source_checksum, kind_of: String, default: 'acf572c606552bc446cceef3f8e93814a363ba0d215b323a2864682b3abfbe45')
+    # attributes used by the tarball-flavor provider
+    attribute(:tarball_url, kind_of: String, default: lazy {  "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{version}.tar.gz" } )
+    attribute(:tarball_checksum, kind_of: String, default: 'acf572c606552bc446cceef3f8e93814a363ba0d215b323a2864682b3abfbe45')
     attribute(:dir, kind_of: String, default: nil)
     attribute(:owner, kind_of: String, default: 'elasticsearch')
     attribute(:group, kind_of: String, default: 'elasticsearch')

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/default.rb
@@ -23,7 +23,7 @@ elasticsearch_install 'elasticsearch_p' do
 end
 
 elasticsearch_install 'elasticsearch_s' do
-  type :source
+  type :tarball
   dir '/usr/local/awesome'
   owner 'foo'
   group 'bar'


### PR DESCRIPTION
Before release, rename source provider to tarball, to better match the purpose.

Closes #332.