### PR TITLE
Test simple plugin install as part of default

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,7 @@ suites:
   - name: default # the normal use-case
     run_list:
       - recipe[java]
-      - recipe[elasticsearch]
+      - recipe[elasticsearch_test::default_with_plugins]
 
   - name: elasticsearch_test # the override-everything use case
     run_list:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ Actions: `:create`, `:remove`
 
 Creates a user and group on the system for use by elasticsearch. Here is an
 example with many of the default options and default values (all options except
-a resource name may be omitted):
+a resource name may be omitted).
 
-```ruby
+Examples:
+
+```
+elasticsearch_user 'elasticsearch'
+```
+
+```
 elasticsearch_user 'elasticsearch' do
   username 'elasticsearch'
   groupname 'elasticsearch'
@@ -49,6 +55,10 @@ particular. This resource also comes with a `:remove` action which will remove
 the package or directory elasticsearch was unpacked into.
 
 Examples:
+
+```
+elasticsearch_install 'elasticsearch'
+```
 
 ```
 elasticsearch_install 'my_es_installation' do
@@ -171,6 +181,10 @@ Actions: `:install`, `:remove`
 
 Installs or removes a plugin to a given elasticsearch instance and plugin
 directory.
+
+```
+elasticsearch_plugin 'mobz/elasticsearch-head'
+```
 
 ```
 elasticsearch_plugin 'mobz/elasticsearch-head' do

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/default_with_plugins.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/default_with_plugins.rb
@@ -1,0 +1,16 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: elasticsearch_test
+# Recipe:: default_with_plugins
+#
+# This cookbook is designed to be just elasticsearch::default plus installing
+# some plugins. We want to test the default plugin resource without any
+# interesting overrides, but don't want to ship that as a recipe in the main
+# cookbook (unlike install, configure, and service, which we do ship in the
+# default cookbook).
+
+# see README.md and test/fixtures/cookbooks for more examples!
+include_recipe 'elasticsearch::default'
+
+# by default, no plugins
+elasticsearch_plugin 'mobz/elasticsearch-head'


### PR DESCRIPTION
- Test default simple plugin install as part of default test suite.
- Add example using the test to the documentation. Add more simple examples to the README.md, demonstrating the defaults. RE: #345