### PR TITLE
Allow the user to override the service actions

### DIFF
--- a/libraries/provider_service.rb
+++ b/libraries/provider_service.rb
@@ -63,7 +63,7 @@ class Chef
 
       service new_resource.service_name do
         supports :status => true, :restart => true
-        action [ :enable ]
+        action   new_resource.service_actions
       end
     end
   end

--- a/libraries/resource_service.rb
+++ b/libraries/resource_service.rb
@@ -24,5 +24,8 @@ class Chef
     # default user limits
     attribute(:memlock_limit, kind_of: String, default: 'unlimited')
     attribute(:nofile_limit, kind_of: String, default: '64000')
+
+    # service actions
+    attribute(:service_actions, kind_of: [Symbol, Array], default: [ :enable ])
   end
 end


### PR DESCRIPTION
Fixes #334 

allows the user to specify their own array of service actions, e.g.

```ruby
elasticsearch_service 'elasticsearch' do
  service_actions [ :enable, :start ]
end
```
