### PR TITLE
Updates docs to show package are now default install

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ elasticsearch_install 'elasticsearch'
 
 ```
 elasticsearch_install 'my_es_installation' do
+  type :package # type of install
+  version "1.7.2"
+  action :install # could be :remove as well
+end
+```
+
+```
+elasticsearch_install 'my_es_installation' do
   type :tarball # type of install
   dir '/usr/local' # where to install
 
@@ -169,13 +177,7 @@ elasticsearch_install 'my_es_installation' do
 end
 ```
 
-```
-elasticsearch_install 'my_es_installation' do
-  type :package # type of install
-  version "1.7.2"
-  action :install # could be :remove as well
-end
-```
+
 
 ### elasticsearch_configure
 Actions: `:manage`, `:remove`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the version parameter as a string into your download_url.
 |Name|Default|Other values|
 |----|-------|------------|
 |`default['elasticsearch']['version']`|`'2.0.0'`|[See list](attributes/default.rb).|
-|`default['elasticsearch']['install_type']`|`:tarball`|`:package`|
+|`default['elasticsearch']['install_type']`|`:package`|`:tarball`|
 |`default['elasticsearch']['download_urls']['debian']`|`'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-%s.deb'`|`%s` will be replaced with the version attribute above|
 |`default['elasticsearch']['download_urls']['rhel']`|`'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-%s.noarch.rpm'`|`%s` will be replaced with the version attribute above|
 |`default['elasticsearch']['download_urls']['tar']`|`'https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-%s.tar.gz'`|`%s` will be replaced with the version attribute above|


### PR DESCRIPTION
According to this comment, packages are now the default install

https://github.com/elastic/cookbook-elasticsearch/issues/384#issuecomment-158693793