### PR TITLE
Adds example how to generate settings dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,19 @@ elasticsearch_configure 'elasticsearch' do
 end
 ```
 
+Enumerate `node['elasticsearch']['config']` attributes from role\environment
+
+```ruby
+node.default['elasticsearch']['config']['cluster.name'] = foobar
+node.default['elasticsearch']['config']['node.name'] = Chef::Config['node_name']
+
+elasticsearch_configure 'elasticsearch' do
+  configuration (node['elasticsearch']['config'])
+  action :manage
+  notifies :restart, 'elasticsearch_service[elasticsearch]'
+end
+```
+
 Very complicated -
 ```ruby
 elasticsearch_configure 'my_elasticsearch' do


### PR DESCRIPTION
Users proabably don't want to hard code all available attributes into wrapper cookbook. Instead dynamically generate them.

Here is what this example replaces

```ruby
elasticsearch_configure 'elasticsearch' do
  configuration ({
    'cluster.name' => clustername,
    'node.name' => Chef::Config[:node_name],
    'path.conf' => node['elasticsearch']['config']['path_conf'],
    'path.data' => node['elasticsearch']['config']['path_data'],
    'path.logs' => node['elasticsearch']['config']['path_logs'],
    'http.port' => node['elasticsearch']['config']['http_port'],
    'node.data' => node['elasticsearch']['config']['node_data'],
    'node.master' => node['elasticsearch']['config']['node_master'],
    'http.enabled' => node['elasticsearch']['config']['http_enabled']
    })
  action :manage
  notifies :restart, 'elasticsearch_service[elasticsearch]'
end
```