### PR TITLE
Update to ES 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the version parameter as a string into your download_url.
 
 |Name|Default|Other values|
 |----|-------|------------|
-|`default['elasticsearch']['version']`|`'2.1.0'`|[See list](attributes/default.rb).|
+|`default['elasticsearch']['version']`|`'2.1.1`|[See list](attributes/default.rb).|
 |`default['elasticsearch']['install_type']`|`:package`|`:tarball`|
 |`default['elasticsearch']['download_urls']['debian']`|[See values](attributes/default.rb).|`%s` will be replaced with the version attribute above|
 |`default['elasticsearch']['download_urls']['rhel']`|[See values](attributes/default.rb).|`%s` will be replaced with the version attribute above|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # elasticsearch version & install type
-default['elasticsearch']['version'] = '2.1.0'
+default['elasticsearch']['version'] = '2.1.1'
 default['elasticsearch']['install_type'] = :package
 
 # platform_family keyed download URLs
@@ -46,3 +46,6 @@ default['elasticsearch']['checksums']['2.0.1']['tar'] = '7be4a6c717002057e422073
 default['elasticsearch']['checksums']['2.1.0']['debian'] = '099fdeb7b3903ce8cea7d39b577ed6445b78b64d14dd2664fd2ca1e0896691dd'
 default['elasticsearch']['checksums']['2.1.0']['rhel'] = 'a79c1985224c1b57479275794b258f4eba973e0b65f5c62b1c38e02738a1ce71'
 default['elasticsearch']['checksums']['2.1.0']['tar'] = '8a4e85bcb506daa369651506af1cbc55c09fd7ff387d111142ae14d0a85d4d14'
+default['elasticsearch']['checksums']['2.1.1']['debian'] = '097400b0b46c826c6a8be837739ade0c0c326b47d38ef54df7bd48de9e9e9995'
+default['elasticsearch']['checksums']['2.1.1']['rhel'] = '22fc646aed2b6900116589a5712ac9324682470336bbbb025b4a607efb735e5a'
+default['elasticsearch']['checksums']['2.1.1']['tar'] = 'ebd69c0483f20ba7e51caa9606d4e3ce5fe2667e1216c799f0cdbb815c317ce6'

--- a/test/integration/helpers/serverspec/install_examples.rb
+++ b/test/integration/helpers/serverspec/install_examples.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 shared_examples_for 'elasticsearch install' do |args = {}|
   dir = args[:dir] || (package? ? '/usr/share/elasticsearch' : '/usr/local')
-  version = args[:version] || '2.1.0'
+  version = args[:version] || '2.1.1'
 
   expected_user = args[:user] || 'elasticsearch'
   expected_group = args[:group] || expected_user || 'elasticsearch'


### PR DESCRIPTION
Bump default version to 2.1.1 and add sha256 hashes for rpm/deb/tar of 2.1.1

Fixes #411