### PR TITLE
Updating to Elasticsearch 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the version parameter as a string into your download_url.
 
 |Name|Default|Other values|
 |----|-------|------------|
-|`default['elasticsearch']['version']`|`'2.1.1'`|[See list](attributes/default.rb).|
+|`default['elasticsearch']['version']`|`'2.2.0'`|[See list](attributes/default.rb).|
 |`default['elasticsearch']['install_type']`|`:package`|`:tarball`|
 |`default['elasticsearch']['download_urls']['debian']`|[See values](attributes/default.rb).|`%s` will be replaced with the version attribute above|
 |`default['elasticsearch']['download_urls']['rhel']`|[See values](attributes/default.rb).|`%s` will be replaced with the version attribute above|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # elasticsearch version & install type
-default['elasticsearch']['version'] = '2.1.1'
+default['elasticsearch']['version'] = '2.2.0'
 default['elasticsearch']['install_type'] = :package
 
 # platform_family keyed download URLs
@@ -49,3 +49,6 @@ default['elasticsearch']['checksums']['2.1.0']['tar'] = '8a4e85bcb506daa36965150
 default['elasticsearch']['checksums']['2.1.1']['debian'] = '097400b0b46c826c6a8be837739ade0c0c326b47d38ef54df7bd48de9e9e9995'
 default['elasticsearch']['checksums']['2.1.1']['rhel'] = '22fc646aed2b6900116589a5712ac9324682470336bbbb025b4a607efb735e5a'
 default['elasticsearch']['checksums']['2.1.1']['tar'] = 'ebd69c0483f20ba7e51caa9606d4e3ce5fe2667e1216c799f0cdbb815c317ce6'
+default['elasticsearch']['checksums']['2.2.0']['debian'] = 'c97ac75303a7ba042c45adff74e27c3584d64d8e0f6f24c43afdcbff484b43d5'
+default['elasticsearch']['checksums']['2.2.0']['rhel'] = '13fe3717e7761f23cd41a148a31ee49496cbdb45f44bfaeb3ba5538a41fdd79a'
+default['elasticsearch']['checksums']['2.2.0']['tar'] = 'ed70cc81e1f55cd5f0032beea2907227b6ad8e7457dcb75ddc97a2cc6e054d30'

--- a/test/integration/helpers/serverspec/install_examples.rb
+++ b/test/integration/helpers/serverspec/install_examples.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 shared_examples_for 'elasticsearch install' do |args = {}|
   dir = args[:dir] || (package? ? '/usr/share/elasticsearch' : '/usr/local')
-  version = args[:version] || '2.1.1'
+  version = args[:version] || '2.2.0'
 
   expected_user = args[:user] || 'elasticsearch'
   expected_group = args[:group] || expected_user || 'elasticsearch'


### PR DESCRIPTION
Set default to 2.2.0, and added hashes for the tar/rpm/deb downloads. 