### PR TITLE
Add checksums for 2.3.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,3 +61,6 @@ default['elasticsearch']['checksums']['2.2.0']['tar'] = 'ed70cc81e1f55cd5f0032be
 default['elasticsearch']['checksums']['2.2.1']['debian'] = 'cb89f880e03276624b3529506c9d2ed6b537968d1c819026e087117cd4c60c7c'
 default['elasticsearch']['checksums']['2.2.1']['rhel'] = 'ddb5e1545e90b45e2b9495c35d5336a40fc63e09d8ac9cac73079888405df7f4'
 default['elasticsearch']['checksums']['2.2.1']['tar'] = '7d43d18a8ee8d715d827ed26b4ff3d939628f5a5b654c6e8de9d99bf3a9b2e03'
+default['elasticsearch']['checksums']['2.3.0']['debian'] = '2645e341587f636edaca1ee1380eeb76596d99b596bf17e03e2c37c697523efd'
+default['elasticsearch']['checksums']['2.3.0']['rhel'] = '7469808bc64bca0b2e1a9fe258ff04ba4acde6c86d13a5cd19d623966fecfffd'
+default['elasticsearch']['checksums']['2.3.0']['tar'] = 'd68482c7633f2986263bc5f11f93b8a58c54c6cf5e337b615446d0a7c6fdcd8b'


### PR DESCRIPTION
This adds the checksums for the Elasticsearch 2.3.0 release.