### PR TITLE
Update documentation for dir in elasticsearch_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ end
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type :tarball # type of install
-  dir '/usr/local' # where to install
+  dir tarball: '/usr/local' # where to install
 
   download_url "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.2.tar.gz"
   # sha256


### PR DESCRIPTION
Using elasticsearch cookbook version 2.3.0 with chef 12.5.1 and passing in `dir '/usr/local'` to `elasticsearch_install` passes on a converge; however, when testing with chef 12.8.1 the following error occurred.

```
$ kitchen converge
-----> Starting Kitchen (v1.6.0)
-----> Using policyfile mode for chef-client
-----> Using policyfile mode for chef-client
-----> Converging <node1-centos-67>...
       Preparing files for transfer
       Preparing dna.json
       Preparing validation.pem
       Preparing client.rb
-----> Chef Omnibus installation detected (12.8.1)
       Transferring files to <node1-centos-67>
       Starting Chef Client, version 12.8.1
       Using policy 'companyname-elasticsearch' at revision 'af7908a6d808c0c79da16290631ad75cd6e8100a20459a8ab9bcaae6c81b785f'
       resolving cookbooks for run list: ["companyname-elasticsearch::default@0.2.0 (6d489b8)", "companyname-elasticsearch::configure@0.2.0 (6d489b8)", "companyname-elasticsearch::es_service@0.2.0 (6d489b8)", "companyname-elasticsearch::nginx_proxy@0.2.0 (6d489b8)", "companyname-elasticsearch::nginx_service@0.2.0 (6d489b8)"]
       Synchronizing Cookbooks:
         - apt (3.0.0)
         - seven_zip (2.0.0)
         - companyname-elasticsearch (0.2.0)
         - chef-sugar (3.3.0)
         - yum (3.10.0)
         - build-essential (3.2.0)
         - elasticsearch (2.3.0)
         - chef_handler (1.3.0)
         - ark (1.0.1)
         - windows (1.39.2)
       Installing Cookbook Gems:
       Compiling Cookbooks...

       ================================================================================
       Recipe Compile Error in /tmp/kitchen/cache/cookbooks/companyname-elasticsearch/recipes/default.rb
       ================================================================================

       Chef::Exceptions::ValidationFailed
       ----------------------------------
       Option dir must be a kind of [Hash]!  You passed "/usr/local".

       Cookbook Trace:
       ---------------
         /tmp/kitchen/cache/cookbooks/companyname-elasticsearch/recipes/default.rb:13:in `block in from_file'
         /tmp/kitchen/cache/cookbooks/companyname-elasticsearch/recipes/default.rb:10:in `from_file'

       Relevant File Content:
       ----------------------
       /tmp/kitchen/cache/cookbooks/companyname-elasticsearch/recipes/default.rb:

         6:  package node['companyname-elasticsearch']['java']['jdk_package']
         7:
         8:  elasticsearch_user 'elasticsearch'
         9:
        10:  elasticsearch_install 'es_install' do
        11:    type :tarball
        12:    # dir { tarball: '/usr/local' }
        13>>   dir '/usr/local'
        14:    action :install
        15:  end
        16:
        17:  elasticsearch_plugin 'elasticsearch/elasticsearch-cloud-aws/2.7.1'
        28:


       Running handlers:
       [2016-04-24T16:05:59+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2016-04-24T16:05:59+00:00] ERROR: Exception handlers complete
       Chef Client failed. 0 resources updated in 05 seconds
       [2016-04-24T16:05:59+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2016-04-24T16:05:59+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2016-04-24T16:05:59+00:00] ERROR: Option dir must be a kind of [Hash]!  You passed "/usr/local".
       [2016-04-24T16:06:00+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
>>>>>> Converge failed on instance <node1-centos-67>.
>>>>>> Please see .kitchen/logs/node1-centos-67.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: SSH exited (1) for command: [sh -c '

sudo -E /opt/chef/bin/chef-client --local-mode --config /tmp/kitchen/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889
']
>>>>>> ----------------------
zlib(finalizer): the stream was freed prematurely.
```

In commit dc77bc5991ea3c0135894055ad6692fad3e3be92, my understanding is that the `dir` attribute was changed from a String to a Hash. This PR updates the Readme to specify a Hash as an argument.

**Invalid configuration:**

```
elasticsearch_install 'es_install' do
  type :tarball
  dir '/usr/local'
  action :install
end
```

**Valid configuration:**

```
elasticsearch_install 'es_install' do
  type :tarball
  dir tarball: '/usr/local'
  action :install
end
```