### PR TITLE
No need for the config yaml files to be executable

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -118,7 +118,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
       cookbook new_resource.cookbook_logging_yml
       owner es_user.username
       group es_user.groupname
-      mode 0755
+      mode 0644
       variables(logging: new_resource.logging)
       action :nothing
     end
@@ -140,7 +140,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
       cookbook new_resource.cookbook_elasticsearch_yml
       owner es_user.username
       group es_user.groupname
-      mode 0755
+      mode 0644
       helpers(ElasticsearchCookbook::Helpers)
       variables(config: merged_configuration)
       action :nothing


### PR DESCRIPTION
This PR changes logging.yml and elasticsearch.yml file permissions from 0755 to 0644, these files should not be executable.