### PR TITLE
Allow enabling/disabling of IPv6

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -90,7 +90,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
     params[:ES_JAVA_OPTS] = ''
     params[:ES_JAVA_OPTS] << '-server '
     params[:ES_JAVA_OPTS] << '-Djava.awt.headless=true '
-    params[:ES_JAVA_OPTS] << '-Djava.net.preferIPv4Stack=true '
+    params[:ES_JAVA_OPTS] << '-Djava.net.preferIPv4Stack=true ' if new_resource.disable_ipv6
     params[:ES_JAVA_OPTS] << "-Xss#{new_resource.thread_stack_size} "
     params[:ES_JAVA_OPTS] << "#{new_resource.gc_settings.tr("\n", ' ')} " if new_resource.gc_settings
     params[:ES_JAVA_OPTS] << '-Dfile.encoding=UTF-8 '

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -59,6 +59,7 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
   attribute(:allocated_memory, kind_of: String)
 
   attribute(:thread_stack_size, kind_of: String, default: '256k')
+  attribute(:disable_ipv6, kind_of: [TrueClass, FalseClass], default: true)
   attribute(:env_options, kind_of: String, default: '')
   attribute(:gc_settings, kind_of: String, default:
     <<-CONFIG


### PR DESCRIPTION
Currently the JVM param '-Djava.net.preferIPv4Stack=true' is hard-coded in the ES_JAVA_OPTS environment variable. This setting effectively disables IPv6 and forces Elasticsearch to listen on IPv4 addresses.

This behavior is causing problems when for example you have the config:```network.host: _local_,_eth0_```. This causes ES to only bind to 127.0.0.1 (and not ::1). A ```curl http://localhost:9200/``` will throw a connection refused in this situation on systems that default to having ```::1     localhost ip6-localhost ip6-loopback``` in /etc/hosts (f.e. Ubuntu 16.04)

It introduces a new property disable_ipv6 to the elasticsearch_configure LWRP, which defaults to true to stick to the current behavior.