### PR TITLE
Fix permissions on environment file

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -103,7 +103,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
       path node['platform_family'] == 'rhel' ? "/etc/sysconfig/#{default_config_name}" : "/etc/default/#{default_config_name}"
       source new_resource.template_elasticsearch_env
       cookbook new_resource.cookbook_elasticsearch_env
-      mode 0755
+      mode 0644
       variables(params: params)
       action :nothing
     end

--- a/test/integration/helpers/serverspec/configure_examples.rb
+++ b/test/integration/helpers/serverspec/configure_examples.rb
@@ -45,6 +45,7 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
 
   describe file(path_sysconfig) do
     it { should be_file }
+    it { should be_mode 644 }
 
     expected_environment.each do |line|
       its(:content) { should contain(/#{line}/) }
@@ -53,6 +54,7 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
 
   describe file("#{path_conf}/elasticsearch.yml") do
     it { should be_file }
+    it { should be_mode 644 }
     it { should be_owned_by expected_user }
     it { should be_grouped_into expected_group }
 
@@ -63,6 +65,7 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
 
   describe file("#{path_conf}/logging.yml") do
     it { should be_file }
+    it { should be_mode 644 }
     it { should be_owned_by expected_user }
     it { should be_grouped_into expected_group }
 


### PR DESCRIPTION
The file /etc/default/elasticsearch / /etc/sysconfig/elasticsearch does not need to be executable