### PR TITLE
Improve environment file formatting

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -87,15 +87,16 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
     params[:MAX_OPEN_FILES] = new_resource.nofile_limit
     params[:MAX_LOCKED_MEMORY] = new_resource.memlock_limit
 
-    params[:ES_JAVA_OPTS] = ''
+    params[:ES_JAVA_OPTS] = '"'
     params[:ES_JAVA_OPTS] << '-server '
     params[:ES_JAVA_OPTS] << '-Djava.awt.headless=true '
     params[:ES_JAVA_OPTS] << '-Djava.net.preferIPv4Stack=true ' if new_resource.disable_ipv6
     params[:ES_JAVA_OPTS] << "-Xss#{new_resource.thread_stack_size} "
-    params[:ES_JAVA_OPTS] << "#{new_resource.gc_settings.tr("\n", ' ')} " if new_resource.gc_settings
+    params[:ES_JAVA_OPTS] << "#{new_resource.gc_settings.tr("\n", ' ').strip.squeeze(' ')} " if new_resource.gc_settings
     params[:ES_JAVA_OPTS] << '-Dfile.encoding=UTF-8 '
-    params[:ES_JAVA_OPTS] << '-Djna.nosys=true '
-    params[:ES_JAVA_OPTS] << "#{new_resource.env_options} " if new_resource.env_options
+    params[:ES_JAVA_OPTS] << '-Djna.nosys=true'
+    params[:ES_JAVA_OPTS] << " #{new_resource.env_options}" if new_resource.env_options
+    params[:ES_JAVA_OPTS] << '"'
 
     default_config_name = es_svc.service_name || es_svc.instance_name || new_resource.instance_name || 'elasticsearch'
 

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -60,7 +60,7 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
 
   attribute(:thread_stack_size, kind_of: String, default: '256k')
   attribute(:disable_ipv6, kind_of: [TrueClass, FalseClass], default: true)
-  attribute(:env_options, kind_of: String, default: '')
+  attribute(:env_options, kind_of: String, default: nil)
   attribute(:gc_settings, kind_of: String, default:
     <<-CONFIG
      -XX:+UseParNewGC

--- a/templates/default/elasticsearch.in.sh.erb
+++ b/templates/default/elasticsearch.in.sh.erb
@@ -9,5 +9,5 @@
 <%
 @params.sort.each do |key, value|
   next if key.nil? || value.nil?
-  %><%= key.to_s %>="<%= value.to_s %>"
+  %><%= key.to_s %>=<%= value.to_s %>
 <% end %>


### PR DESCRIPTION
This PR brings the contents of /etc/default/elasticsearch / /etc/sysconfig/elasticsearch more in line with the format that the Elasticsearch package uses. It removes quotes from vars that don't need it, and strips superfluous spaces from ES_JAVA_OPTS for a cleaner look. Tested on Ubuntu 14.04 and CentOS 6.

It also fixes a tiny cosmetic bug that resulted in env_options being included in ES_JAVA_OPTS because the default was '' instead of nil.

Before:
```
CONF_DIR="/etc/elasticsearch"
DATA_DIR="/usr/share/elasticsearch"
ES_GROUP="elasticsearch"
ES_HEAP_SIZE="496m"
ES_HOME="/usr/share/elasticsearch"
ES_JAVA_OPTS="-server -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Xss256k      -XX:+UseParNewGC      -XX:+UseConcMarkSweepGC      -XX:CMSInitiatingOccupancyFraction=75      -XX:+UseCMSInitiatingOccupancyOnly      -XX:+HeapDumpOnOutOfMemoryError      -XX:+DisableExplicitGC  -Dfile.encoding=UTF-8 -Djna.nosys=true  "
ES_STARTUP_SLEEP_TIME="5"
ES_USER="elasticsearch"
LOG_DIR="/var/log/elasticsearch"
MAX_LOCKED_MEMORY="unlimited"
MAX_OPEN_FILES="64000"
PID_DIR="/var/run/elasticsearch"
```

After:
```
CONF_DIR=/etc/elasticsearch
DATA_DIR=/usr/share/elasticsearch
ES_GROUP=elasticsearch
ES_HEAP_SIZE=496m
ES_HOME=/usr/share/elasticsearch
ES_JAVA_OPTS="-server -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Xss256k -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+DisableExplicitGC -Dfile.encoding=UTF-8 -Djna.nosys=true"
ES_STARTUP_SLEEP_TIME=5
ES_USER=elasticsearch
LOG_DIR=/var/log/elasticsearch
MAX_LOCKED_MEMORY=unlimited
MAX_OPEN_FILES=64000
PID_DIR=/var/run/elasticsearch
```