### PR TITLE
Make plugin matching case-insensitive.

### DIFF
--- a/libraries/provider_plugin.rb
+++ b/libraries/provider_plugin.rb
@@ -47,7 +47,7 @@ class ElasticsearchCookbook::PluginProvider < Chef::Provider::LWRPBase
 
     Dir.entries(path).any? do |plugin|
       next if plugin =~ /^\./
-      name.include? plugin
+      name.downcase.include? plugin
     end
   rescue
     false


### PR DESCRIPTION
I ran into this using the "royrusso/elasticsearch-HQ" plugin, which `bin/plugin list` will show as "hq".