### PR TITLE
lock down permissions on elasticsearch.yml

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -141,7 +141,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
       cookbook new_resource.cookbook_elasticsearch_yml
       owner es_user.username
       group es_user.groupname
-      mode 0644
+      mode 0600
       helpers(ElasticsearchCookbook::Helpers)
       variables(config: merged_configuration)
       action :nothing


### PR DESCRIPTION
Some modules (cloud-aws for example) support setting passwords or other secrets in elasticsearch.yml.  Since the owner and group are already being set to the elasticsearch user, leaving it world readable just makes it difficult to use those features and protect secrets at the same time.