### PR TITLE
only use es_env_file if exists

### DIFF
--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -51,6 +51,7 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
   attribute(:logging, kind_of: Hash, default: {}.freeze)
 
   attribute(:java_home, kind_of: String, default: nil)
+  attribute(:es_include, kind_of: [TrueClass, FalseClass], default: true)
 
   attribute(:startup_sleep_seconds, kind_of: [String, Integer], default: 5)
 


### PR DESCRIPTION
- Export ES_ENV_FILE as ES_INCLUDE because ES merges default
  options (from file elasticsearch.in.sh) and from ES_ENV_FILE (for example java_opts ....). Just want
  to use from ES_ENV_FILE if exists

- Add ES_CLASSPATH in ES_ENV_FILE needed to start ES