### PR TITLE
ES 2.4.1 checksums + use for install/tests default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the version parameter as a string into your download_url.
 
 |Name|Default|Other values|
 |----|-------|------------|
-|`default['elasticsearch']['version']`|`'2.4.0'`|[See list](attributes/default.rb).|
+|`default['elasticsearch']['version']`|`'2.4.1'`|[See list](attributes/default.rb).|
 |`default['elasticsearch']['install_type']`|`:package`|`:tarball`|
 |`default['elasticsearch']['download_urls']['debian']`|[See values](attributes/default.rb).|`%s` will be replaced with the version attribute above|
 |`default['elasticsearch']['download_urls']['rhel']`|[See values](attributes/default.rb).|`%s` will be replaced with the version attribute above|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # elasticsearch version & install type
-default['elasticsearch']['version'] = '2.4.0'
+default['elasticsearch']['version'] = '2.4.1'
 default['elasticsearch']['install_type'] = :package
 
 # platform_family keyed download URLs
@@ -85,3 +85,6 @@ default['elasticsearch']['checksums']['2.3.5']['tar'] = '1119a8c18620b98c4b85261
 default['elasticsearch']['checksums']['2.4.0']['debian'] = '5edf1ac795d6950781b20ecc8db992d6dc95e55abb1ff66e6b1234d85bd68514'
 default['elasticsearch']['checksums']['2.4.0']['rhel'] = 'aa75abe581685cb5767ce91a042b8b395290d966bcb575ff2e3d1cf1fd06ff7f'
 default['elasticsearch']['checksums']['2.4.0']['tar'] = '3ae01140ae7bcbb91436feef381fbed774e36ef6d1e8e6a3153640db82acf4c9'
+default['elasticsearch']['checksums']['2.4.1']['debian'] = 'cdf94b84cbf3024961cd09a689957fe39df6da9afcfe76ceba20dbfb50b92945'
+default['elasticsearch']['checksums']['2.4.1']['rhel'] = 'c8a275d12876165da532ebfde1eeb6a502613bda919d95516f30f6495ae5086d'
+default['elasticsearch']['checksums']['2.4.1']['tar'] = '23a369ef42955c19aaaf9e34891eea3a055ed217d7fbe76da0998a7a54bbe167'

--- a/test/integration/helpers/serverspec/install_examples.rb
+++ b/test/integration/helpers/serverspec/install_examples.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 shared_examples_for 'elasticsearch install' do |args = {}|
   dir = args[:dir] || (package? ? '/usr/share/elasticsearch' : '/usr/local')
-  version = args[:version] || '2.4.0'
+  version = args[:version] || '2.4.1'
 
   expected_user = args[:user] || 'elasticsearch'
   expected_group = args[:group] || expected_user || 'elasticsearch'


### PR DESCRIPTION
Hi! Updating the cookbook to be able to handle ES 2.4.1 and install it in lieu of 2.4.0.