### PR TITLE
Updated to 5.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ elasticsearch_install 'elasticsearch'
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type 'package' # type of install
-  version "5.1.1"
+  version "5.1.2"
   action :install # could be :remove as well
 end
 ```
@@ -173,7 +173,7 @@ end
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type 'tarball' # type of install
-  version '5.1.1'
+  version '5.1.2'
   action :install # could be :remove as well
 end
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,3 +29,7 @@ default['elasticsearch']['checksums']['5.0.2']['tarball'] = 'bbe761788570d344801
 default['elasticsearch']['checksums']['5.1.1']['debian'] = 'c8a38990a24b558fb9c65492034caa00044e638d0ede6d440b00cb4eacb46d1d'
 default['elasticsearch']['checksums']['5.1.1']['rhel'] = '94cd4d9a3c307e4128bfae159e5c18a149e522cb8ab51089e969d9f1ed830805'
 default['elasticsearch']['checksums']['5.1.1']['tarball'] = 'cd45bafb1f74a7df9bad12c77b7bf3080069266bcbe0b256b0959ef2536e31e8'
+
+default['elasticsearch']['checksums']['5.1.2']['debian'] = '411091695ff9188b9394816f88f3328f478c4d21e2a80ce194660ee14b868475'
+default['elasticsearch']['checksums']['5.1.2']['rhel'] = 'c507b71c84be94d63b1bdb664396a769cbff5022e9e2279efd2ce166cbac6ced'
+default['elasticsearch']['checksums']['5.1.2']['tarball'] = '74d752f9a8b46898d306ad169b72f328e17215c0909149e156a576089ef11c42'

--- a/libraries/resource_install.rb
+++ b/libraries/resource_install.rb
@@ -11,7 +11,7 @@ class ElasticsearchCookbook::InstallResource < Chef::Resource::LWRPBase
 
   # if this version parameter is not set by the caller, we look at
   # `attributes/default.rb` for a default value to use, or we raise
-  attribute(:version, kind_of: String, default: '5.1.1')
+  attribute(:version, kind_of: String, default: '5.1.2')
 
   # we allow a string or symbol for this value
   attribute(:type, kind_of: String, equal_to: %w(package tarball repository), default: 'repository')

--- a/test/integration/helpers/serverspec/install_examples.rb
+++ b/test/integration/helpers/serverspec/install_examples.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 shared_examples_for 'elasticsearch install' do |args = {}|
   dir = args[:dir] || '/usr/share'
-  version = args[:version] || '5.1.1'
+  version = args[:version] || '5.1.2'
 
   expected_user = args[:user] || 'elasticsearch'
   expected_group = args[:group] || expected_user || 'elasticsearch'


### PR DESCRIPTION
Updated default Elasticsearch version to 5.1.2.