### PR TITLE
Make service definition scripts configurable

### DIFF
--- a/libraries/provider_service.rb
+++ b/libraries/provider_service.rb
@@ -36,7 +36,12 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
       mode '0755'
       variables(
         # we need to include something about #{progname} fixed in here.
-        program_name: new_resource.service_name
+        program_name: new_resource.service_name,
+        path_home: es_conf.path_home,
+        path_conf: es_conf.path_conf,
+        path_data: es_conf.path_data,
+        path_logs: es_conf.path_logs,
+        path_pid: es_conf.path_pid
       )
       only_if { ::File.exist?('/etc/init.d') }
       action :nothing
@@ -65,7 +70,12 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
         path_home: es_conf.path_home,
         es_user: es_user.username,
         es_group: es_user.groupname,
-        nofile_limit: es_conf.nofile_limit
+        nofile_limit: es_conf.nofile_limit,
+        path_home: es_conf.path_home,
+        path_conf: es_conf.path_conf,
+        path_data: es_conf.path_data,
+        path_logs: es_conf.path_logs,
+        path_pid: es_conf.path_pid
       )
       only_if 'which systemctl'
       action :nothing

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'karel.minarik@elasticsearch.org'
 license          'Apache 2.0'
 description      'Installs and configures Elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.3'
+version          '3.0.4'
 
 supports 'amazon'
 supports 'centos'

--- a/templates/amazon/initscript.erb
+++ b/templates/amazon/initscript.erb
@@ -34,14 +34,14 @@ fi
 # Sets the default values for elasticsearch variables used in this script
 ES_USER="elasticsearch"
 ES_GROUP="elasticsearch"
-ES_HOME="/usr/share/elasticsearch"
 MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
-LOG_DIR="/var/log/elasticsearch"
-DATA_DIR="/var/lib/elasticsearch"
-CONF_DIR="/etc/elasticsearch"
 
-PID_DIR="/var/run/elasticsearch"
+ES_HOME="<%= @path_home %>"
+LOG_DIR="<%= @path_logs %>"
+DATA_DIR="<%= @path_data %>"
+CONF_DIR="<%= @path_conf %>"
+PID_DIR="<%= @path_pid %>"
 
 # Source the default env file
 ES_ENV_FILE="/etc/sysconfig/<%= @program_name %>"

--- a/templates/centos/initscript.erb
+++ b/templates/centos/initscript.erb
@@ -34,14 +34,14 @@ fi
 # Sets the default values for elasticsearch variables used in this script
 ES_USER="elasticsearch"
 ES_GROUP="elasticsearch"
-ES_HOME="/usr/share/elasticsearch"
 MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
-LOG_DIR="/var/log/elasticsearch"
-DATA_DIR="/var/lib/elasticsearch"
-CONF_DIR="/etc/elasticsearch"
 
-PID_DIR="/var/run/elasticsearch"
+ES_HOME="<%= @path_home %>"
+LOG_DIR="<%= @path_logs %>"
+DATA_DIR="<%= @path_data %>"
+CONF_DIR="<%= @path_conf %>"
+PID_DIR="<%= @path_pid %>"
 
 # Source the default env file
 ES_ENV_FILE="/etc/sysconfig/<%= @program_name %>"

--- a/templates/debian/initscript.erb
+++ b/templates/debian/initscript.erb
@@ -37,7 +37,7 @@ ES_USER=elasticsearch
 ES_GROUP=elasticsearch
 
 # Directory where the Elasticsearch binary distribution resides
-ES_HOME=/usr/share/$NAME
+ES_HOME="<%= @path_home %>"
 
 # Additional Java OPTS
 #ES_JAVA_OPTS=
@@ -49,19 +49,19 @@ MAX_OPEN_FILES=65536
 #MAX_LOCKED_MEMORY=
 
 # Elasticsearch log directory
-LOG_DIR=/var/log/$NAME
+LOG_DIR="<%= @path_logs %>"
 
 # Elasticsearch data directory
-DATA_DIR=/var/lib/$NAME
+DATA_DIR="<%= @path_data %>"
 
 # Elasticsearch configuration directory
-CONF_DIR=/etc/$NAME
+CONF_DIR="<%= @path_conf %>"
 
 # Maximum number of VMA (Virtual Memory Areas) a process can own
 MAX_MAP_COUNT=262144
 
 # Elasticsearch PID file directory
-PID_DIR="/var/run/elasticsearch"
+PID_DIR="<%= @path_pid %>"
 
 # End of variables that can be overwritten in $DEFAULT
 

--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -5,11 +5,11 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Environment=ES_HOME=/usr/share/elasticsearch
-Environment=CONF_DIR=/etc/elasticsearch
-Environment=DATA_DIR=/var/lib/elasticsearch
-Environment=LOG_DIR=/var/log/elasticsearch
-Environment=PID_DIR=/var/run/elasticsearch
+Environment=ES_HOME=<%= @path_home %>
+Environment=CONF_DIR=<%= @path_conf %>
+Environment=DATA_DIR=<%= @path_data %>
+Environment=LOG_DIR=<%= @path_logs %>
+Environment=PID_DIR=<%= @path_pid %>
 EnvironmentFile=-<%= @default_dir %>/<%= @program_name %>
 
 WorkingDirectory=<%= @path_home %>

--- a/templates/oracle/initscript.erb
+++ b/templates/oracle/initscript.erb
@@ -37,11 +37,12 @@ ES_GROUP="elasticsearch"
 ES_HOME="/usr/share/elasticsearch"
 MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
-LOG_DIR="/var/log/elasticsearch"
-DATA_DIR="/var/lib/elasticsearch"
-CONF_DIR="/etc/elasticsearch"
 
-PID_DIR="/var/run/elasticsearch"
+ES_HOME="<%= @path_home %>"
+LOG_DIR="<%= @path_logs %>"
+DATA_DIR="<%= @path_data %>"
+CONF_DIR="<%= @path_conf %>"
+PID_DIR="<%= @path_pid %>"
 
 # Source the default env file
 ES_ENV_FILE="/etc/sysconfig/<%= @program_name %>"

--- a/templates/redhat/initscript.erb
+++ b/templates/redhat/initscript.erb
@@ -34,14 +34,14 @@ fi
 # Sets the default values for elasticsearch variables used in this script
 ES_USER="elasticsearch"
 ES_GROUP="elasticsearch"
-ES_HOME="/usr/share/elasticsearch"
 MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
-LOG_DIR="/var/log/elasticsearch"
-DATA_DIR="/var/lib/elasticsearch"
-CONF_DIR="/etc/elasticsearch"
 
-PID_DIR="/var/run/elasticsearch"
+ES_HOME="<%= @path_home %>"
+LOG_DIR="<%= @path_logs %>"
+DATA_DIR="<%= @path_data %>"
+CONF_DIR="<%= @path_conf %>"
+PID_DIR="<%= @path_pid %>"
 
 # Source the default env file
 ES_ENV_FILE="/etc/sysconfig/<%= @program_name %>"

--- a/templates/ubuntu/initscript.erb
+++ b/templates/ubuntu/initscript.erb
@@ -37,7 +37,7 @@ ES_USER=elasticsearch
 ES_GROUP=elasticsearch
 
 # Directory where the Elasticsearch binary distribution resides
-ES_HOME=/usr/share/$NAME
+ES_HOME="<%= @path_home %>"
 
 # Additional Java OPTS
 #ES_JAVA_OPTS=
@@ -49,19 +49,19 @@ MAX_OPEN_FILES=65536
 #MAX_LOCKED_MEMORY=
 
 # Elasticsearch log directory
-LOG_DIR=/var/log/$NAME
+LOG_DIR="<%= @path_logs %>"
 
 # Elasticsearch data directory
-DATA_DIR=/var/lib/$NAME
+DATA_DIR="<%= @path_data %>"
 
 # Elasticsearch configuration directory
-CONF_DIR=/etc/$NAME
+CONF_DIR="<%= @path_conf %>"
 
 # Maximum number of VMA (Virtual Memory Areas) a process can own
 MAX_MAP_COUNT=262144
 
 # Elasticsearch PID file directory
-PID_DIR="/var/run/elasticsearch"
+PID_DIR="<%= @path_pid %>"
 
 # End of variables that can be overwritten in $DEFAULT
 


### PR DESCRIPTION
Thank you for cookbook.

@martinb3 @karmi @tas50

Releases after v2.4.0 introduced a lot of incompatible and breaking changes. 

Prior to v2.4.0+ default installation path was /usr/local nevertheless it is configurable through `elasticsearch_configure` resource is incomplete since service definition scripts use hard coded values.

This change makes major path variables configurable. 