### PR TITLE
Allow others to read elasticsearch log dir

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -37,7 +37,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
 
     # Create ES directories
     #
-    [new_resource.path_conf, "#{new_resource.path_conf}/scripts", new_resource.path_logs].each do |path|
+    [new_resource.path_conf, "#{new_resource.path_conf}/scripts"].each do |path|
       d = directory path do
         owner es_user.username
         group es_user.groupname
@@ -52,6 +52,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
     # Create data path directories
     #
     data_paths = new_resource.path_data.is_a?(Array) ? new_resource.path_data : new_resource.path_data.split(',')
+    data_paths = data_paths << new_resource.path_logs
 
     data_paths.each do |path|
       d = directory path.strip do

--- a/test/integration/helpers/serverspec/configure_examples.rb
+++ b/test/integration/helpers/serverspec/configure_examples.rb
@@ -38,17 +38,17 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
     'java.awt.headless=true',
   ]
 
-  describe file(path_data) do
+  describe file(path_conf) do
     it { should be_directory }
-    it { should be_mode 755 }
+    it { should be_mode 750 }
     it { should be_owned_by expected_user } unless package?
     it { should be_grouped_into expected_group } unless package?
   end
 
-  [path_conf, path_logs].each do |p|
+  [path_data, path_logs].each do |p|
     describe file(p) do
       it { should be_directory }
-      it { should be_mode 750 }
+      it { should be_mode 755 }
       it { should be_owned_by expected_user } unless package?
       it { should be_grouped_into expected_group } unless package?
     end


### PR DESCRIPTION
This will allow 'others' users to read /var/log/elasticsearch directory