### PR TITLE
Updating cookbook metadata.rb to new version for 5.4.0 release.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'karel.minarik@elasticsearch.org'
 license          'Apache 2.0'
 description      'Installs and configures Elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.1'
+version          '3.2.0'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
The Chef SuperMarket needs to be updated as well for the new version of the cookbook for general use.