### PR TITLE
provider_user.rb

### DIFF
--- a/libraries/provider_user.rb
+++ b/libraries/provider_user.rb
@@ -22,7 +22,7 @@ class ElasticsearchCookbook::UserProvider < Chef::Provider::LWRPBase
       shell   new_resource.shell
       uid     new_resource.uid
       gid     new_resource.groupname
-      supports(manage_home: false)
+      manage_home false
       action :nothing
       system true
     end


### PR DESCRIPTION
Support for Chef-client 13.

 supports { manage_home: false } on the user resource is deprecated and will be removed in Chef 13, set manage_home false instead at 1 location:
    - /var/chef/cache/cookbooks/elasticsearch/libraries/provider_user.rb:25:in `block (2 levels) in <class:UserProvider>'
   See https://docs.chef.io/deprecations_supports_property.html for further details.