### PR TITLE
Allow to use chef resource notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ including a demonstration of how to configure two instances of Elasticsearch on 
 
 The resources provided in this cookbook **do not automatically restart** services when changes have occurred. They ***do start services by default when configuring a new service*** This has been done to protect you from accidental data loss and service outages, as nodes might restart simultaneously or may not restart at all when bad configuration values are supplied.
 
-elasticsearch_service has a special `service_actions` parameter you can use to specify what state the underlying service should be in on each chef run (defaults to `:enabled` and `:started`). It will also pass through all of the standard `service` resource
-actions to the underlying service resource if you wish to notify it.
-
 You **must** supply your desired notifications when using each resource if you want Chef to automatically restart services. Again, we don't recommend this unless you know what you're doing.
 
 ### Resource names

--- a/libraries/provider_service.rb
+++ b/libraries/provider_service.rb
@@ -8,16 +8,16 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
   end
 
   use_inline_resources
-  def action_remove
+  action :remove do
     raise "#{new_resource} remove not currently implemented"
   end
 
-  def action_configure
+  action :configure do
     es_user = find_es_resource(Chef.run_context, :elasticsearch_user, new_resource)
     es_conf = find_es_resource(Chef.run_context, :elasticsearch_configure, new_resource)
     default_config_name = new_resource.service_name || new_resource.instance_name || es_conf.instance_name || 'elasticsearch'
 
-    d_r = directory "#{es_conf.path_pid}-#{default_config_name}" do
+    directory "#{es_conf.path_pid}-#{default_config_name}" do
       path es_conf.path_pid
       owner es_user.username
       group es_user.groupname
@@ -79,32 +79,31 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
       end
       reload_r.run_action(:run)
     end
-
   end
 
   # Passthrough actions to service[service_name]
   #
-  def action_enable
+  action :enable do
     passthrough_action(:enable)
   end
 
-  def action_disable
+  action :disable do
     passthrough_action(:disable)
   end
 
-  def action_start
+  action :start do
     passthrough_action(:start)
   end
 
-  def action_stop
+  action :stop do
     passthrough_action(:stop)
   end
 
-  def action_restart
+  action :restart do
     passthrough_action(:restart)
   end
 
-  def action_status
+  action :status do
     passthrough_action(:status)
   end
 

--- a/libraries/resource_service.rb
+++ b/libraries/resource_service.rb
@@ -15,9 +15,6 @@ class ElasticsearchCookbook::ServiceResource < Chef::Resource::LWRPBase
   attribute(:service_name, kind_of: String, name_attribute: true)
   attribute(:args, kind_of: String, default: '-d')
 
-  # service actions
-  attribute(:service_actions, kind_of: [Symbol, String, Array], default: [:enable, :start].freeze)
-
   # allow overridable init script
   attribute(:init_source, kind_of: String, default: 'initscript.erb')
   attribute(:init_cookbook, kind_of: String, default: 'elasticsearch')

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/doubleinstances.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/doubleinstances.rb
@@ -52,6 +52,6 @@ settings = {
 
   elasticsearch_service "elasticsearch_#{instance_name}" do
     instance_name instance_name
-    service_actions [:enable, :start]
+    action [:enable, :start]
   end
 end

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/package.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/package.rb
@@ -45,5 +45,5 @@ end
 
 elasticsearch_service 'elasticsearch-crazy' do
   instance_name 'special_package_instance'
-  service_actions [:enable, :start]
+  action [:enable, :start]
 end

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/tarball.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/tarball.rb
@@ -52,5 +52,5 @@ elasticsearch_service 'elasticsearch-crazy' do
   # path_conf '/usr/local/awesome/etc/elasticsearch'
   # path_pid '/usr/local/awesome/var/run'
   instance_name 'special_tarball_instance'
-  service_actions [:enable, :start]
+  action [:enable, :start]
 end


### PR DESCRIPTION
In order to use chef resource notifications we need to:
* Enable whyrun for elasticsearch_service
* Get rid of service_actions