### PR TITLE
[Fixes #598] Support mixed Hash/ImmutableMash configs in elasticsearch.yml

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -123,4 +123,24 @@ module ElasticsearchCookbook
       ''
     end
   end
+
+  class HashAndMashBlender
+    attr_accessor :target
+    def initialize(hash_or_mash_or_whatever)
+      self.target = hash_or_mash_or_whatever
+    end
+
+    def to_hash
+      target.each_with_object({}) do |(k, v), hsh|
+        hsh[k] =
+          if v.respond_to?(:to_hash)
+            self.class.new(v).to_hash
+          elsif v.respond_to?(:to_a)
+            v.to_a
+          else
+            v
+          end
+      end
+    end
+  end
 end

--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -148,6 +148,8 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
       Chef::Log.warn("Please change the following to strings in order to work with this Elasticsearch cookbook: #{found_symbols.join(',')}")
     end
 
+    config_vars = ElasticsearchCookbook::HashAndMashBlender.new(merged_configuration).to_hash
+
     yml_template = template "elasticsearch.yml-#{default_config_name}" do
       path "#{new_resource.path_conf}/elasticsearch.yml"
       source new_resource.template_elasticsearch_yml
@@ -156,7 +158,7 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
       group es_user.groupname
       mode '0640'
       helpers(ElasticsearchCookbook::Helpers)
-      variables(config: merged_configuration)
+      variables(config: config_vars)
       action :nothing
     end
     yml_template.run_action(:create)


### PR DESCRIPTION
@martinb3, I think this is the smallest implementation I could think of to solve the problem described in #598 and earlier in the closed issue #590.

For Chef/Ruby combinations that don't have the problem described in #590 this change acts like a null-op. For those that do, this change forces the Chef::Node::ImmutableArray and Chef::Node::ImmutableMash to cast themselves as pure Ruby arrays and hashes respestively prior to serialization into elasticsearch.yml.