### PR TITLE
Set LimitMEMLOCK=infinity in systemd if memlock_limit is unlimited

### DIFF
--- a/libraries/provider_service.rb
+++ b/libraries/provider_service.rb
@@ -65,6 +65,7 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
         path_home: es_conf.path_home,
         es_user: es_user.username,
         es_group: es_user.groupname,
+        memlock_limit: es_conf.memlock_limit,
         nofile_limit: es_conf.nofile_limit
       )
       only_if 'which systemctl'

--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -41,7 +41,7 @@ LimitNOFILE=<%= @nofile_limit %>
 # Specifies the maximum number of bytes of memory that may be locked into RAM
 # Set to "infinity" if you use the 'bootstrap.memory_lock: true' option
 # in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in <%= @default_dir %>/<%= @program_name %>
-#LimitMEMLOCK=infinity
+<% if @memlock_limit != 'unlimited' %>#<% end %>LimitMEMLOCK=infinity
 
 # Disable timeout logic and wait until process is stopped
 TimeoutStopSec=0


### PR DESCRIPTION
This change aims to uncomment the "Set LimitMEMLOCK=infinity" directive in the systemd file when the memlock_limit attribute is set to unlimited.