### PR TITLE
Rely on logger.action set from attributes, as having it declared twic…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'karel.minarik@elasticsearch.org'
 license          'Apache 2.0'
 description      'Installs and configures Elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.5.0'
+version          '2.5.1'
 
 supports 'amazon'
 supports 'centos'

--- a/templates/default/logging.yml.erb
+++ b/templates/default/logging.yml.erb
@@ -15,9 +15,6 @@
 es.logger.level: INFO
 rootLogger: ${es.logger.level}, console, file
 logger:
-  # log action execution errors for easier debugging
-  action: DEBUG
-
   # deprecation logging, turn to DEBUG to see them
   deprecation: INFO, deprecation_log_file
 
@@ -44,7 +41,7 @@ logger:
 
 # ----- Configuration set by Chef ---------------------------------------------
 <% @logging.sort.each do |key, value| %>
-logger.<%= key %>: <%= value %>
+  <%= key %>: <%= value %>
 <% end %>
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
…e was breaking log4j

I know this is an old branch, but I found a bug that required me to fork the cookbook. Any chance we could get this merged in? This was breaking all elasticsearch logging outside of journalctl.

Signed-off-by: Josh Hudson <jhudson@chef.io>