### PR TITLE
make enabling console logging configurable

### DIFF
--- a/libraries/provider_service.rb
+++ b/libraries/provider_service.rb
@@ -68,7 +68,8 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
           path_home: es_conf.path_home,
           es_user: es_user.username,
           es_group: es_user.groupname,
-          nofile_limit: es_conf.nofile_limit
+          nofile_limit: es_conf.nofile_limit,
+          service_quiet: es_conf.service_quiet,
         )
         only_if 'which systemctl'
         action :nothing

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -91,4 +91,5 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
   # wipe out all default settings, your configuration items should go here.
   #
   attribute(:configuration, kind_of: Hash, default: {}.freeze)
+  attribute(:service_quiet, kind_of: [TrueClass, FalseClass], default: true)
 end

--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -19,9 +19,8 @@ Group=<%= @es_group %>
 
 ExecStartPre=<%= @path_home %>/bin/elasticsearch-systemd-pre-exec
 
-ExecStart=<%= @path_home %>/bin/elasticsearch \
+ExecStart=<%= @path_home %>/bin/elasticsearch <% if @quiet%>--quiet<% end %>\
                                                 -p ${PID_DIR}/elasticsearch.pid \
-                                                --quiet \
                                                 -Edefault.path.logs=${LOG_DIR} \
                                                 -Edefault.path.data=${DATA_DIR} \
                                                 -Edefault.path.conf=${CONF_DIR}


### PR DESCRIPTION
When --quiet is passed in systemd the console appender breaks; this pr is to make it configurable.
Since that setting must be specified using the ExecStart directive it we can not perform an override as with the LimitMEMLOCK parameter (see https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-system-settings.html#systemd for reference). This the reason we need this change.
Best regards
@jfwm2