### PR TITLE
removing options that cause ES 6.1.0 to fail to start.

### DIFF
--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -79,8 +79,6 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
     params[:LOG_DIR] = new_resource.path_logs
     params[:PID_DIR] = new_resource.path_pid
     params[:RESTART_ON_UPGRADE] = new_resource.restart_on_upgrade
-    params[:ES_USER] = es_user.username
-    params[:ES_GROUP] = es_user.groupname
     params[:ES_STARTUP_SLEEP_TIME] = new_resource.startup_sleep_seconds.to_s
     params[:MAX_OPEN_FILES] = new_resource.nofile_limit
     params[:MAX_LOCKED_MEMORY] = new_resource.memlock_limit


### PR DESCRIPTION
I've been testing the cookbook with ES 6.1.  Having these env vars made ES fail to start.