### PR TITLE
Update repos and remove path.conf 

### DIFF
--- a/libraries/provider_install.rb
+++ b/libraries/provider_install.rb
@@ -209,16 +209,16 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
   end
 
   def yum_repo_resource
-    yum_repository 'elastic-5.x' do
-      baseurl 'https://artifacts.elastic.co/packages/5.x/yum'
+    yum_repository 'elastic-6.x' do
+      baseurl 'https://artifacts.elastic.co/packages/6.x/yum'
       gpgkey 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
       action :nothing # :add, remove
     end
   end
 
   def apt_repo_resource
-    apt_repository 'elastic-5.x' do
-      uri 'https://artifacts.elastic.co/packages/5.x/apt'
+    apt_repository 'elastic-6.x' do
+      uri 'https://artifacts.elastic.co/packages/6.x/apt'
       key 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
       components ['main']
       distribution 'stable'

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -74,7 +74,7 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
     'node.name' => Chef::Config[:node_name],
 
     # if omitted or nil, these will be populated from attributes above
-    'path.conf' => nil, # see path_conf above
+    # 'path.conf' => nil, # see path_conf above
     'path.data' => nil, # see path_data above
     'path.logs' => nil, # see path_logs above
 

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -74,7 +74,6 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
     'node.name' => Chef::Config[:node_name],
 
     # if omitted or nil, these will be populated from attributes above
-    # 'path.conf' => nil, # see path_conf above
     'path.data' => nil, # see path_data above
     'path.logs' => nil, # see path_logs above
 


### PR DESCRIPTION
I updated the package repos to include the 6.x base URLs and remove the path.conf deprecated resource value. 

Related to #593 and  #634 