### PR TITLE
Add support for 5.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ elasticsearch_install 'elasticsearch'
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type 'package' # type of install
-  version '5.6.5'
+  version '5.6.6'
   action :install # could be :remove as well
 end
 ```
@@ -172,7 +172,7 @@ end
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type 'tarball' # type of install
-  version '5.6.5'
+  version '5.6.6'
   action :install # could be :remove as well
 end
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -117,3 +117,7 @@ default['elasticsearch']['checksums']['5.6.4']['tarball'] = '1098fc776fae8c74e65
 default['elasticsearch']['checksums']['5.6.5']['debian'] = '8be33a173f1f1df4f75ce0bbf2ca9d274217b94c603bac18455542c0bc1e8728'
 default['elasticsearch']['checksums']['5.6.5']['rhel'] = '663493e7be193fc304a4378a0130c85bfb89578f5559a34fde333e07a5655305'
 default['elasticsearch']['checksums']['5.6.5']['tarball'] = 'baffbc799e8457575f250176b58923cccc4de561d3439045ccbed72344397ab2'
+
+default['elasticsearch']['checksums']['5.6.5']['debian'] = 'a0c0ecd97d60d9b441924c51c0c03ce989c2becb18d6ce34e03a9dfa3634a200'
+default['elasticsearch']['checksums']['5.6.5']['rhel'] = '60ce6755810550b2288aa612595cf95fdf9386d017f558e324af28248a2c424a'
+default['elasticsearch']['checksums']['5.6.5']['tarball'] = 'f4f2d8ab87f408db4ab379e56ca5d147bf3f4c6f6885693f4ebbbdb6e4df5272'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,6 +118,6 @@ default['elasticsearch']['checksums']['5.6.5']['debian'] = '8be33a173f1f1df4f75c
 default['elasticsearch']['checksums']['5.6.5']['rhel'] = '663493e7be193fc304a4378a0130c85bfb89578f5559a34fde333e07a5655305'
 default['elasticsearch']['checksums']['5.6.5']['tarball'] = 'baffbc799e8457575f250176b58923cccc4de561d3439045ccbed72344397ab2'
 
-default['elasticsearch']['checksums']['5.6.5']['debian'] = 'a0c0ecd97d60d9b441924c51c0c03ce989c2becb18d6ce34e03a9dfa3634a200'
-default['elasticsearch']['checksums']['5.6.5']['rhel'] = '60ce6755810550b2288aa612595cf95fdf9386d017f558e324af28248a2c424a'
-default['elasticsearch']['checksums']['5.6.5']['tarball'] = 'f4f2d8ab87f408db4ab379e56ca5d147bf3f4c6f6885693f4ebbbdb6e4df5272'
+default['elasticsearch']['checksums']['5.6.6']['debian'] = 'a0c0ecd97d60d9b441924c51c0c03ce989c2becb18d6ce34e03a9dfa3634a200'
+default['elasticsearch']['checksums']['5.6.6']['rhel'] = '60ce6755810550b2288aa612595cf95fdf9386d017f558e324af28248a2c424a'
+default['elasticsearch']['checksums']['5.6.6']['tarball'] = 'f4f2d8ab87f408db4ab379e56ca5d147bf3f4c6f6885693f4ebbbdb6e4df5272'

--- a/libraries/resource_install.rb
+++ b/libraries/resource_install.rb
@@ -11,7 +11,7 @@ class ElasticsearchCookbook::InstallResource < Chef::Resource::LWRPBase
 
   # if this version parameter is not set by the caller, we look at
   # `attributes/default.rb` for a default value to use, or we raise
-  attribute(:version, kind_of: String, default: '5.6.5')
+  attribute(:version, kind_of: String, default: '5.6.6')
 
   # we allow a string or symbol for this value
   attribute(:type, kind_of: String, equal_to: %w(package tarball repository), default: 'repository')

--- a/test/integration/helpers/serverspec/install_examples.rb
+++ b/test/integration/helpers/serverspec/install_examples.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 shared_examples_for 'elasticsearch install' do |args = {}|
   dir = args[:dir] || '/usr/share'
-  version = args[:version] || '5.6.5'
+  version = args[:version] || '5.6.6'
 
   expected_user = args[:user] || 'elasticsearch'
   expected_group = args[:group] || expected_user || 'elasticsearch'


### PR DESCRIPTION
This adds support for 5.6.6 

Note: URLS listed on the release page for 5.6.6 are incorrect, they are pointing at the 5.6.5 files.

https://www.elastic.co/downloads/past-releases/elasticsearch-5-6-6