### PR TITLE
Add support for 6.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ elasticsearch_install 'elasticsearch'
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type 'package' # type of install
-  version '6.1.1'
+  version '6.1.2'
   action :install # could be :remove as well
 end
 ```
@@ -172,7 +172,7 @@ end
 ```ruby
 elasticsearch_install 'my_es_installation' do
   type 'tarball' # type of install
-  version '6.1.1'
+  version '6.1.2'
   action :install # could be :remove as well
 end
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,3 +29,7 @@ default['elasticsearch']['checksums']['6.1.0']['tarball'] = 'c879fe2698635a2f132
 default['elasticsearch']['checksums']['6.1.1']['debian'] = '8b6e65dce742c733aa61da24f9c8c0d4d4b7f53ae11d7f4168e98b5a0ed58b45'
 default['elasticsearch']['checksums']['6.1.1']['rhel'] = '9820555c72b61b54686bcf0697cdabace28b02315bb5a156999495a16b103d5a'
 default['elasticsearch']['checksums']['6.1.1']['tarball'] = '0cadc90c2ab1bd941e3965eef96fbc2c08b12b832ae81f5882e81505333b74b6'
+
+default['elasticsearch']['checksums']['6.1.2']['debian'] = '64d8bd2bd895904bb91daff656764b10da93531f2011c94d7c779124e53dd5f5'
+default['elasticsearch']['checksums']['6.1.2']['rhel'] = 'bfa6809ac94bda92a4ec1bf601c8266f82a4c7842a7702da4dede8f7d5c6a2ec'
+default['elasticsearch']['checksums']['6.1.2']['tarball'] = '9c0eae0bdab78c59dac0ba3a9c054e6785dc0f5ce4666e284f42010a326abc0f'

--- a/libraries/resource_install.rb
+++ b/libraries/resource_install.rb
@@ -11,7 +11,7 @@ class ElasticsearchCookbook::InstallResource < Chef::Resource::LWRPBase
 
   # if this version parameter is not set by the caller, we look at
   # `attributes/default.rb` for a default value to use, or we raise
-  attribute(:version, kind_of: String, default: '6.1.1')
+  attribute(:version, kind_of: String, default: '6.1.2')
 
   # we allow a string or symbol for this value
   attribute(:type, kind_of: String, equal_to: %w(package tarball repository), default: 'repository')

--- a/test/integration/helpers/serverspec/install_examples.rb
+++ b/test/integration/helpers/serverspec/install_examples.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 shared_examples_for 'elasticsearch install' do |args = {}|
   dir = args[:dir] || '/usr/share'
-  version = args[:version] || '6.1.1'
+  version = args[:version] || '6.1.2'
 
   expected_user = args[:user] || 'elasticsearch'
   expected_group = args[:group] || expected_user || 'elasticsearch'


### PR DESCRIPTION
Add hashes and update defaults for 6.1.2. https://www.elastic.co/downloads/past-releases/elasticsearch-6-1-2