### PR TITLE
Bump to 5.6.5

### DIFF
--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -65,4 +65,4 @@ SuccessExitStatus=143
 [Install]
 WantedBy=multi-user.target
 
-# Built for distribution-5.6.2 (distribution)
+# Built for distribution-5.6.5 (distribution)


### PR DESCRIPTION
This is simply to fix chef-client changing back the version in the init file :
 +++ /usr/lib/systemd/system/.chef-elasticsearch20180201-11647-uc5t0v.service      2018-02-01 10:53:30.794493963 +0000
      @@ -65,5 +65,5 @@
       [Install]
       WantedBy=multi-user.target

      -# Built for distribution-5.6.5 (distribution)
      +# Built for distribution-5.6.2 (distribution)