### PR TITLE
Remove/jvm options management

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ Lint/RescueException:
     - 'Rakefile'
     - 'libraries/helpers.rb'
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Exclude:
     - 'Rakefile'
     - 'libraries/helpers.rb'

--- a/README.md
+++ b/README.md
@@ -246,19 +246,6 @@ elasticsearch_configure 'my_elasticsearch' do
 
   allocated_memory '123m'
 
-  jvm_options %w(
-                -XX:+UseParNewGC
-                -XX:+UseConcMarkSweepGC
-                -XX:CMSInitiatingOccupancyFraction=75
-                -XX:+UseCMSInitiatingOccupancyOnly
-                -XX:+HeapDumpOnOutOfMemoryError
-                -XX:+PrintGCDetails
-              )
-
-  configuration ({
-    'node.name' => 'crazy'
-  })
-
   action :manage
 end
 ```

--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -99,25 +99,6 @@ class ElasticsearchCookbook::ConfigureProvider < Chef::Provider::LWRPBase
     shell_template.run_action(:create)
     new_resource.updated_by_last_action(true) if shell_template.updated_by_last_action?
 
-    # Create jvm.options file
-    #
-    jvm_options_template = template "jvm_options-#{default_config_name}" do
-      path   "#{new_resource.path_conf}/jvm.options"
-      source new_resource.template_jvm_options
-      cookbook new_resource.cookbook_jvm_options
-      owner es_user.username
-      group es_user.groupname
-      mode '0644'
-      variables(jvm_options: [
-        "-Xms#{new_resource.allocated_memory}",
-        "-Xmx#{new_resource.allocated_memory}",
-        new_resource.jvm_options,
-      ].flatten.join("\n"))
-      action :nothing
-    end
-    jvm_options_template.run_action(:create)
-    new_resource.updated_by_last_action(true) if jvm_options_template.updated_by_last_action?
-
     # Create ES logging file
     #
     logging_template = template "log4j2_properties-#{default_config_name}" do

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -21,9 +21,6 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
   attribute(:template_elasticsearch_env, kind_of: String, default: 'elasticsearch.in.sh.erb')
   attribute(:cookbook_elasticsearch_env, kind_of: String, default: 'elasticsearch')
 
-  attribute(:template_jvm_options, kind_of: String, default: 'jvm_options.erb')
-  attribute(:cookbook_jvm_options, kind_of: String, default: 'elasticsearch')
-
   attribute(:template_elasticsearch_yml, kind_of: String, default: 'elasticsearch.yml.erb')
   attribute(:cookbook_elasticsearch_yml, kind_of: String, default: 'elasticsearch')
 
@@ -43,26 +40,6 @@ class ElasticsearchCookbook::ConfigureResource < Chef::Resource::LWRPBase
   # Calculations for this are done in the provider, as we can't do them in the
   # resource definition. default is 50% of RAM or 31GB, which ever is smaller.
   attribute(:allocated_memory, kind_of: String)
-
-  attribute(:jvm_options, kind_of: Array, default:
-    %w(
-      -XX:+UseConcMarkSweepGC
-      -XX:CMSInitiatingOccupancyFraction=75
-      -XX:+UseCMSInitiatingOccupancyOnly
-      -XX:+AlwaysPreTouch
-      -server
-      -Xss1m
-      -Djava.awt.headless=true
-      -Dfile.encoding=UTF-8
-      -Djna.nosys=true
-      -XX:-OmitStackTraceInFastThrow
-      -Dio.netty.noUnsafe=true
-      -Dio.netty.noKeySetOptimization=true
-      -Dio.netty.recycler.maxCapacityPerThread=0
-      -Dlog4j.shutdownHookEnabled=false
-      -Dlog4j2.disable.jmx=true
-      -XX:+HeapDumpOnOutOfMemoryError
-    ).freeze)
 
   # These are the default settings. Most of the time, you want to override
   # the `configuration` attribute below. If you do override the defaults, you

--- a/templates/default/jvm_options.erb
+++ b/templates/default/jvm_options.erb
@@ -1,3 +1,0 @@
-## JVM configuration
-
-<%= @jvm_options %>

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/package.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/package.rb
@@ -22,17 +22,6 @@ elasticsearch_configure 'my_elasticsearch' do
 
   allocated_memory '123m'
 
-  jvm_options %w(
-    -server
-    -Djava.awt.headless=true
-    -XX:+UseParNewGC
-    -XX:+UseConcMarkSweepGC
-    -XX:CMSInitiatingOccupancyFraction=75
-    -XX:+UseCMSInitiatingOccupancyOnly
-    -XX:+HeapDumpOnOutOfMemoryError
-    -XX:+PrintGCDetails
-  )
-
   configuration('node.name' => 'arbitrary_name')
   # plugin_dir '/usr/local/awesome/elasticsearch-1.7.3/plugins'
   action :manage
@@ -45,5 +34,5 @@ end
 
 elasticsearch_service 'elasticsearch-crazy' do
   instance_name 'special_package_instance'
-  service_actions [:enable, :start]
+  service_actions %i[enable start]
 end

--- a/test/fixtures/cookbooks/elasticsearch_test/recipes/tarball.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/recipes/tarball.rb
@@ -30,15 +30,6 @@ elasticsearch_configure 'my_elasticsearch' do
 
   allocated_memory '123m'
 
-  jvm_options %w(
-    -XX:+UseParNewGC
-    -XX:+UseConcMarkSweepGC
-    -XX:CMSInitiatingOccupancyFraction=75
-    -XX:+UseCMSInitiatingOccupancyOnly
-    -XX:+HeapDumpOnOutOfMemoryError
-    -XX:+PrintGCDetails
-  )
-
   configuration('node.name' => 'crazy')
   action :manage
   instance_name 'special_tarball_instance'
@@ -52,5 +43,5 @@ elasticsearch_service 'elasticsearch-crazy' do
   # path_conf '/usr/local/awesome/etc/elasticsearch'
   # path_pid '/usr/local/awesome/var/run'
   instance_name 'special_tarball_instance'
-  service_actions [:enable, :start]
+  service_actions %i[enable start]
 end

--- a/test/integration/helpers/serverspec/configure_examples.rb
+++ b/test/integration/helpers/serverspec/configure_examples.rb
@@ -13,7 +13,7 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
     'cluster.name: elasticsearch',
     'node.name: .+',
     'path.data: \/.+',
-    'path.logs: \/.+',
+    'path.logs: \/.+'
   ]
 
   expected_environment = args[:env] || [
@@ -28,13 +28,7 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
     'MAX_MAP_COUNT=.+',
     'MAX_OPEN_FILES=.+',
     'PID_DIR=.+',
-    'RESTART_ON_UPGRADE=.+',
-  ]
-
-  expected_jvm_options = args[:jvmopts] || [
-    'server',
-    'HeapDumpOnOutOfMemoryError',
-    'java.awt.headless=true',
+    'RESTART_ON_UPGRADE=.+'
   ]
 
   describe file(path_conf) do
@@ -69,17 +63,6 @@ shared_examples_for 'elasticsearch configure' do |args = {}|
     it { should be_grouped_into expected_group }
 
     expected_config.each do |line|
-      its(:content) { should contain(/#{line}/) }
-    end
-  end
-
-  describe file("#{path_conf}/jvm.options") do
-    it { should be_file }
-    it { should be_mode 644 }
-    it { should be_owned_by expected_user }
-    it { should be_grouped_into expected_group }
-
-    expected_jvm_options.each do |line|
       its(:content) { should contain(/#{line}/) }
     end
   end


### PR DESCRIPTION
https://github.com/elastic/cookbook-elasticsearch/blob/master/CHANGELOG.md#v400-2018-03-25

```
ES_JVM_OPTIONS is no longer supported in v6.0.0
```

Since ES6 does not support jvm options there is no reason to configure them.