### PR TITLE
v1.x.x. chef 13 support

### DIFF
--- a/libraries/provider_user.rb
+++ b/libraries/provider_user.rb
@@ -23,7 +23,6 @@ class Chef
           shell   new_resource.shell
           uid     new_resource.uid
           gid     new_resource.groupname
-          supports manage_home: false
           action :nothing
           system true
         end


### PR DESCRIPTION
`supports` attribute of `user` resource not recognized in Chef 13.x.

Error:
`undefined method 'supports' for Chef::Resource::User::LinuxUser`