### PR TITLE
Add --background flag to avoid hangups

### DIFF
--- a/templates/ubuntu/initscript.erb
+++ b/templates/ubuntu/initscript.erb
@@ -129,7 +129,14 @@ case "$1" in
 	fi
 
 	# Start Daemon
-	start-stop-daemon -d $ES_HOME --start --user elasticsearch -c elasticsearch --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	start-stop-daemon -d $ES_HOME \
+	                  --start \
+			  --background \
+	                  --user elasticsearch \
+			  -c elasticsearch \
+			  --pidfile "$PID_FILE" \
+			  --exec $DAEMON \
+			  -- $DAEMON_OPTS
 	return=$?
 	if [ $return -eq 0 ]; then
 		i=0


### PR DESCRIPTION
Trying to start elasticsearch via `/usr/sbin/service elasticsearch start`
via non-interactive ssh leads to the service not being up once the ssh session terminates.