### PR TITLE
Added elasticsearch_plugin resource attribute batch

### DIFF
--- a/libraries/provider_plugin.rb
+++ b/libraries/provider_plugin.rb
@@ -14,7 +14,8 @@ class ElasticsearchCookbook::PluginProvider < Chef::Provider::LWRPBase
 
     # since install can take a URL argument instead
     url_or_name = new_resource.url || new_resource.plugin_name
-    manage_plugin("install #{url_or_name}")
+    batch_arg = new_resource.batch ? '--batch' : ''
+    manage_plugin("install #{batch_arg} #{url_or_name}")
   end # action
 
   def action_remove

--- a/libraries/resource_plugin.rb
+++ b/libraries/resource_plugin.rb
@@ -12,6 +12,7 @@ class ElasticsearchCookbook::PluginResource < Chef::Resource::LWRPBase
   attribute(:plugin_name, kind_of: String, name_attribute: true)
   attribute(:url, kind_of: String, default: nil)
   attribute(:chef_proxy, kind_of: [TrueClass, FalseClass], default: false)
+  attribute(:batch, kind_of: [TrueClass, FalseClass], default: false)
   attribute(:options, kind_of: String, default: '')
 
   # this is what helps the various resources find each other


### PR DESCRIPTION
By default `elasticsearch_install` resource attribute`batch` is set to `false`.

Setting attribute `batch` to true will add  `--batch` option to elasticsearch plugin install command.