### PR TITLE
joshphp/remove_package_by_name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,8 @@ default['elasticsearch']['download_urls'] = {
   'tarball' => 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-%s.tar.gz',
 }
 
+default['elasticsearch']['package_base_name'] = 'elasticsearch'
+
 # platform_family keyed download sha256 checksums
 default['elasticsearch']['checksums']['6.0.0']['debian'] = '28f38779156387c1db274d8d733429e574b54b4f518da6f0741f6276f8229939'
 default['elasticsearch']['checksums']['6.0.0']['rhel'] = '823fa8aa24e9948dea30f0a468f0403b34a62180e02ed752443d5964334c29a1'

--- a/libraries/provider_install.rb
+++ b/libraries/provider_install.rb
@@ -140,11 +140,11 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
     filename = package_url.split('/').last
 
     pkg_r = if node['platform_family'] == 'debian'
-              dpkg_package "#{Chef::Config[:file_cache_path]}/#{filename}" do
+              dpkg_package "#{node['elasticsearch']['package_base_name']}" do
                 action :nothing
               end
             else
-              package "#{Chef::Config[:file_cache_path]}/#{filename}" do
+              package "#{node['elasticsearch']['package_base_name']}" do
                 action :nothing
               end
             end


### PR DESCRIPTION
Fixes elastic/cookbook-elasticsearch#688

When using `elasticsearch_install` to remove the package, it trys to remove it and references the package in the `file_cache_path`. This just tells the native package manager to remove the package by name, allowing you to uninstall and reinstall.

Please let me know if you would like to see this implemented differently. I don't love this method but it solves the issue and does not break functionality that currently exists. 