### PR TITLE
Attempt to fix Travis builds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ Style/RescueModifier:
     - 'libraries/helpers.rb'
 
 Style/GuardClause:
+  Enabled: false
   Exclude:
     - 'Rakefile'
     - 'libraries/helpers.rb'
@@ -56,5 +57,15 @@ Style/ClassAndModuleChildren:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Style/GuardClause:
-  Enabled: false
+# Cookstyle specific things
+ChefStyle/CommentFormat:
+  Enabled: False # we are not Chef
+
+ChefModernize/WhyRunSupportedTrue:
+  Enabled: False # we are still supporting v12
+
+ChefModernize/RespondToInMetadata:
+  Enabled: False # we're supporting 12.5 still
+
+ChefModernize/DefinesChefSpecMatchers:
+  Enabled: False # we haven't moved to newer ChefSpec yet

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
 sudo: false
 
 rvm:
-  - 2.3.1
+  - 2.5.7
 
 install: bundle install --jobs=3 --retry=3 --without kitchen_vagrant kitchen_rackspace kitchen_ec2 development
 cache:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,6 @@ maintainer       'Karel Minarik'
 maintainer_email 'karel.minarik@elasticsearch.org'
 license          'Apache-2.0'
 description      'Installs and configures Elasticsearch'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '4.2.0'
 
 supports 'amazon'

--- a/test/fixtures/cookbooks/elasticsearch_test/metadata.rb
+++ b/test/fixtures/cookbooks/elasticsearch_test/metadata.rb
@@ -2,9 +2,8 @@
 name             'elasticsearch_test'
 maintainer       'Karel Minarik'
 maintainer_email 'karel.minarik@elasticsearch.org'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'A wrapper cookbook for use in testing that elasticsearch cookbook works well with wrappers calling it'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends 'apt'

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -42,5 +42,3 @@ def stub_chef_zero(platform, version, server)
     server.create_environment(env_name, env_data)
   end
 end
-
-at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
We're currently seeing:
```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby
    chef (~> 14.0) was resolved to 14.14.29, which depends on
      Ruby (>= 2.4.0)
The command "bundle install --jobs=3 --retry=3 --without kitchen_vagrant kitchen_rackspace kitchen_ec2 development" failed and exited with 6 during .
```
