### PR TITLE
Kill the elasticsearch process if stop times out

### DIFF
--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -52,7 +52,7 @@ KillSignal=SIGTERM
 KillMode=process
 
 # Java process is never killed
-SendSIGKILL=no
+SendSIGKILL=yes
 
 # When a JVM receives a SIGTERM signal it exits with code 143
 SuccessExitStatus=143


### PR DESCRIPTION
This change to the systemd unit file should kill the ES process if a timeout occurs when attempting to stop it. 