### PR TITLE
fix: add frozen_string_literal and amazonlinux-2023 to dokken

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -25,6 +25,11 @@ platforms:
       image: dokken/almalinux-10
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: amazonlinux-2023
+    driver:
+      image: dokken/amazonlinux-2023
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9

--- a/spec/version_helpers_spec.rb
+++ b/spec/version_helpers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../libraries/versions'
 
 RSpec.describe ElasticsearchCookbook::VersionHelpers do


### PR DESCRIPTION
- Add missing `frozen_string_literal: true` to `spec/version_helpers_spec.rb`
- Add `amazonlinux-2023` platform to `kitchen.dokken.yml` to match `kitchen.yml`