### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook dependency resolution
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb                   # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs and configures Elasticsearch
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,30 +21,30 @@ GPG key: `https://artifacts.elastic.co/GPG-KEY-elasticsearch`
 
 ### APT (Debian/Ubuntu)
 
-- Ubuntu 20.04: ES 7.x, 8.x (amd64, arm64)
-- Ubuntu 22.04: ES 7.x, 8.x (amd64, arm64)
-- Ubuntu 24.04: ES 8.x (amd64, arm64)
-- Debian 11: ES 7.x, 8.x (amd64, arm64)
-- Debian 12: ES 7.x, 8.x (amd64, arm64)
-- Debian 13: ES 8.x (amd64, arm64)
+* Ubuntu 20.04: ES 7.x, 8.x (amd64, arm64)
+* Ubuntu 22.04: ES 7.x, 8.x (amd64, arm64)
+* Ubuntu 24.04: ES 8.x (amd64, arm64)
+* Debian 11: ES 7.x, 8.x (amd64, arm64)
+* Debian 12: ES 7.x, 8.x (amd64, arm64)
+* Debian 13: ES 8.x (amd64, arm64)
 
 ### DNF/YUM (RHEL family)
 
-- RHEL 8 / AlmaLinux 8 / Rocky Linux 8 / Oracle Linux 8: ES 7.x, 8.x (x86_64, aarch64)
-- RHEL 9 / AlmaLinux 9 / Rocky Linux 9 / Oracle Linux 9: ES 7.x, 8.x (x86_64, aarch64)
-- AlmaLinux 10 / Rocky Linux 10 / CentOS Stream 10: ES 8.x (x86_64, aarch64)
-- CentOS Stream 9: ES 7.x, 8.x (x86_64, aarch64)
-- Amazon Linux 2023: ES 8.x (x86_64, aarch64)
-- Fedora (latest): ES 8.x (x86_64, aarch64)
+* RHEL 8 / AlmaLinux 8 / Rocky Linux 8 / Oracle Linux 8: ES 7.x, 8.x (x86_64, aarch64)
+* RHEL 9 / AlmaLinux 9 / Rocky Linux 9 / Oracle Linux 9: ES 7.x, 8.x (x86_64, aarch64)
+* AlmaLinux 10 / Rocky Linux 10 / CentOS Stream 10: ES 8.x (x86_64, aarch64)
+* CentOS Stream 9: ES 7.x, 8.x (x86_64, aarch64)
+* Amazon Linux 2023: ES 8.x (x86_64, aarch64)
+* Fedora (latest): ES 8.x (x86_64, aarch64)
 
 ### Zypper (SUSE)
 
-- openSUSE Leap 15: ES 7.x, 8.x (x86_64, aarch64) — RPM packages via YUM repository
+* openSUSE Leap 15: ES 7.x, 8.x (x86_64, aarch64) — RPM packages via YUM repository
 
 ## Architecture Limitations
 
-- aarch64/arm64 packages available since ES 7.12+
-- All platforms support both amd64/x86_64 and arm64/aarch64
+* aarch64/arm64 packages available since ES 7.12+
+* All platforms support both amd64/x86_64 and arm64/aarch64
 
 ## Source/Compiled Installation
 
@@ -61,21 +61,21 @@ The cookbook declares: `amazon`, `centos`, `debian`, `fedora`, `redhat`, `ubuntu
 
 These platforms are tested in `kitchen.dokken.yml` but not declared in `metadata.rb`:
 
-- `almalinux` — RHEL derivative, works via `platform_family?('rhel')`
-- `rockylinux` — RHEL derivative, works via `platform_family?('rhel')`
-- `oraclelinux` — RHEL derivative, works via `platform_family?('rhel')`
-- `opensuse` — uses YUM/Zypper repository; supported by Elastic
+* `almalinux` — RHEL derivative, works via `platform_family?('rhel')`
+* `rockylinux` — RHEL derivative, works via `platform_family?('rhel')`
+* `oraclelinux` — RHEL derivative, works via `platform_family?('rhel')`
+* `opensuse` — uses YUM/Zypper repository; supported by Elastic
 
 ### Not supported by this cookbook
 
-- SUSE Linux Enterprise Server (SLES) — no `zypper_repository` resource in the cookbook
-- Windows, macOS — not applicable for this cookbook
+* SUSE Linux Enterprise Server (SLES) — no `zypper_repository` resource in the cookbook
+* Windows, macOS — not applicable for this cookbook
 
 ## Known Issues
 
-- Default version in `_common.rb` partial is `7.17.9`; ES 8.x is the current major release
-- The `versions.rb` checksum library only covers ES 6.x–8.6.2; newer 8.x versions require the repository install type
-- Tarball install type raises an error — no systemd service template for tarball installs
+* Default version in `_common.rb` partial is `7.17.9`; ES 8.x is the current major release
+* The `versions.rb` checksum library only covers ES 6.x–8.6.2; newer 8.x versions require the repository install type
+* Tarball install type raises an error — no systemd service template for tarball installs
 
 ## Disabled Platforms
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+name 'elasticsearch'
+
+run_list 'test::default'
+
+cookbook 'elasticsearch', path: '.'
+cookbook 'ark', git: 'https://github.com/sous-chefs/ark.git', branch: 'main'
+cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
+cookbook 'seven_zip', git: 'https://github.com/sous-chefs/seven_zip.git', branch: 'main'
+cookbook 'yum', git: 'https://github.com/sous-chefs/yum.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -210,7 +210,7 @@ action :manage do
   merged_configuration = default_configuration.merge(new_resource.configuration.dup)
 
   # Warn if someone is using symbols. We don't support.
-  found_symbols = merged_configuration.keys.select { |s| s.is_a?(Symbol) }
+  found_symbols = merged_configuration.keys.grep(Symbol)
   unless found_symbols.empty?
     Chef::Log.warn("Please change the following to strings in order to work with this Elasticsearch cookbook: #{found_symbols.join(',')}")
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -2,6 +2,3 @@
 name: default
 title: Default Tests for ElasticSearch
 summary: This InSpec profile contains integration tests for the ElasticSearch cookbook
-supports:
-  - os-family: linux
-  - os-family: bsd

--- a/test/integration/package/inspec.yml
+++ b/test/integration/package/inspec.yml
@@ -1,9 +1,6 @@
 name: elasticsearch package test
 title: Elasticsearch Package Test
 version: 0.1.0
-supports:
-  - os-family: linux
-  - os-family: bsd
 depends:
   - name: default
     path: test/integration/default

--- a/test/integration/repository/inspec.yml
+++ b/test/integration/repository/inspec.yml
@@ -1,9 +1,6 @@
 name: elasticsearch repository test
 title: Elasticsearch Repository Test
 version: 0.1.0
-supports:
-  - os-family: linux
-  - os-family: bsd
 depends:
   - name: default
     path: test/integration/default


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress